### PR TITLE
Fix WILCO becoming unavailable when a station reuses a MIN

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+# Scoped to tests/ deliberately: src/utils/test_simbrief.py is a manual script
+# that calls the live SimBrief API, and pytest would otherwise collect it.
+testpaths = tests
+pythonpath = .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==9.1.1

--- a/src/controller/polling_controller.py
+++ b/src/controller/polling_controller.py
@@ -6,6 +6,7 @@ import wx
 
 from hoppie_connector import HoppieMessage, CpdlcMessage, TelexMessage
 from src.model.connection_manager import ConnectionManager
+from src.model.message_manager import CPDLC_RESPONSES
 from src.utils.message_formatting import extract_message_content
 
 
@@ -169,20 +170,12 @@ class PollingController:
         if isinstance(message, CpdlcMessage):
             content = message.get_packet_content()
             if content:
-                # Check for common acknowledgement messages
-                ack_responses = [
-                    "WILCO",
-                    "UNABLE",
-                    "ROGER",
-                    "AFFIRM",
-                    "NEGATIVE",
-                    "YES",
-                    "NO",
-                ]
                 clean_content = extract_message_content(content)
 
-                # If the message only contains an acknowledgement, don't increase polling
-                if clean_content in ack_responses:
+                # If the message only contains an acknowledgement, don't
+                # increase polling. CPDLC_RESPONSES is shared with
+                # MessageManager so the two lists cannot drift apart.
+                if clean_content in CPDLC_RESPONSES:
                     return False
 
         # For all other message types, increase polling rate

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -124,7 +124,11 @@ class MainWindow(wx.Frame):
 
         # Create message view
         self.message_view = MessageView(
-            self.panel, self.logger, self.message_manager, self._on_acknowledge_message
+            self.panel,
+            self.logger,
+            self.message_manager,
+            self._on_acknowledge_message,
+            self.cpdlc_session.get_current_station,
         )
 
         # Create status bar
@@ -789,10 +793,13 @@ class MainWindow(wx.Frame):
                 if msg_text == "LOGON ACCEPTED":
                     # Handle automatic handovers or explicit logon acceptance
                     mrn = message.get_mrn() if hasattr(message, "get_mrn") else None
-                    self.cpdlc_session.handle_logon_accepted(sender, mrn=mrn)
-                    # Update UI
-                    self.SetStatusText(f"Logged on to {sender}.")
-                    self.logger.info(f"Logon accepted by {sender}")
+                    # Only report the logon if the session actually accepted it;
+                    # a stale acceptance from a previously contacted station is
+                    # ignored and must not be announced as success.
+                    if self.cpdlc_session.handle_logon_accepted(sender, mrn=mrn):
+                        # Update UI
+                        self.SetStatusText(f"Logged on to {sender}.")
+                        self.logger.info(f"Logon accepted by {sender}")
 
                 # Check for HANDOVER message from current station
                 elif sender == self.cpdlc_session.get_current_station():
@@ -856,29 +863,28 @@ class MainWindow(wx.Frame):
                                     f"Auto-tune failed \u2014 set {freq:.3f} manually"
                                 )
 
-    def _on_acknowledge_message(self, message_id, response):
+    def _on_acknowledge_message(self, message_id: int, response: str):
         """Handle message acknowledgement.
 
         Args:
             message_id: The ID of the message being acknowledged
             response: The response text
         """
-        message = self.message_manager.get_message(message_id)
-        if message is None:
+        addressing = self.message_manager.get_cpdlc_addressing(message_id)
+        if addressing is None:
             self.logger.warning(f"Cannot acknowledge unknown message ID {message_id}")
+            self.SetStatusText("Could not send response: message unavailable.")
             return
 
-        sender = message.get_from_name()
-        min_value = message.get_min()
+        sender, min_value = addressing
 
         success, returned_message = self.cpdlc_session.send_acknowledgement(
             sender, min_value, response
         )
         if success:
-            # STANDBY sends the response but does NOT mark as acknowledged,
-            # allowing the pilot to respond again later with WILCO/UNABLE etc.
-            if response != "STANDBY":
-                self.message_manager.mark_acknowledged(message_id)
+            # MessageManager decides whether this response retires the message;
+            # STANDBY is sent but leaves it answerable.
+            self.message_manager.mark_acknowledged(message_id, response)
 
             # Add custom message only if a message was returned from the session
             if returned_message:

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -856,13 +856,18 @@ class MainWindow(wx.Frame):
                                     f"Auto-tune failed \u2014 set {freq:.3f} manually"
                                 )
 
-    def _on_acknowledge_message(self, message, response):
+    def _on_acknowledge_message(self, message_id, response):
         """Handle message acknowledgement.
 
         Args:
-            message: The message being acknowledged
+            message_id: The ID of the message being acknowledged
             response: The response text
         """
+        message = self.message_manager.get_message(message_id)
+        if message is None:
+            self.logger.warning(f"Cannot acknowledge unknown message ID {message_id}")
+            return
+
         sender = message.get_from_name()
         min_value = message.get_min()
 
@@ -873,7 +878,7 @@ class MainWindow(wx.Frame):
             # STANDBY sends the response but does NOT mark as acknowledged,
             # allowing the pilot to respond again later with WILCO/UNABLE etc.
             if response != "STANDBY":
-                self.message_manager.mark_acknowledged(message)
+                self.message_manager.mark_acknowledged(message_id)
 
             # Add custom message only if a message was returned from the session
             if returned_message:

--- a/src/gui/message_view.py
+++ b/src/gui/message_view.py
@@ -2,7 +2,6 @@
 
 import wx
 
-from hoppie_connector import HoppieMessage, CpdlcMessage
 from src.model.message_manager import MessageManager
 
 
@@ -10,7 +9,12 @@ class MessageView:
     """Handles display and interaction with CPDLC messages."""
 
     def __init__(
-        self, parent, logger, message_manager: MessageManager, on_acknowledge=None
+        self,
+        parent,
+        logger,
+        message_manager: MessageManager,
+        on_acknowledge,
+        get_current_station,
     ):
         """Initialize the message view.
 
@@ -19,11 +23,14 @@ class MessageView:
             logger: Application logger
             message_manager: Message manager instance
             on_acknowledge: Callback for message acknowledgement
+            get_current_station: Callable returning the station currently
+                logged on, used to scope responses to the live dialogue
         """
         self.parent = parent
         self.logger = logger
         self.message_manager = message_manager
         self.on_acknowledge = on_acknowledge
+        self.get_current_station = get_current_station
 
         self._init_ui()
 
@@ -33,7 +40,12 @@ class MessageView:
         hbox = wx.BoxSizer(wx.HORIZONTAL)
 
         # Create message list
-        self.message_list = wx.ListCtrl(self.parent, style=wx.LC_REPORT)
+        # LC_SINGLE_SEL keeps GetFirstSelected() unambiguous: with multiple
+        # rows selected it returns the lowest-indexed one, which need not be
+        # the row the user is looking at or right-clicked.
+        self.message_list = wx.ListCtrl(
+            self.parent, style=wx.LC_REPORT | wx.LC_SINGLE_SEL
+        )
         self.message_list.InsertColumn(0, "Sender", width=-1)
         self.message_list.InsertColumn(1, "Message", width=-1)
         self.message_list.SetToolTip("Messages received from the CPDLC network.")
@@ -99,14 +111,13 @@ class MessageView:
             return
 
         message_id = self.message_list.GetItemData(selected_index)
-        message = self.message_manager.get_message(message_id)
 
-        if not isinstance(message, HoppieMessage):
-            self.logger.debug(f"Selected item (ID={message_id}) is not a HoppieMessage")
-            return
-
-        self.logger.debug(f"Checking message: {message}")
-        needs_ack, responses = self.message_manager.needs_acknowledgement(message_id)
+        # needs_acknowledgement resolves the ID itself and rejects anything
+        # that is not an unanswered CPDLC message from the current station.
+        self.logger.debug(f"Checking message ID={message_id}")
+        needs_ack, responses = self.message_manager.needs_acknowledgement(
+            message_id, self.get_current_station()
+        )
 
         if not needs_ack:
             self.logger.debug(

--- a/src/gui/message_view.py
+++ b/src/gui/message_view.py
@@ -106,7 +106,7 @@ class MessageView:
             return
 
         self.logger.debug(f"Checking message: {message}")
-        needs_ack, responses = self.message_manager.needs_acknowledgement(message)
+        needs_ack, responses = self.message_manager.needs_acknowledgement(message_id)
 
         if not needs_ack:
             self.logger.debug(
@@ -123,8 +123,8 @@ class MessageView:
             menu_items.append(menu_item)
             self.parent.Bind(
                 wx.EVT_MENU,
-                lambda event, resp=response, msg=message: self._handle_acknowledge(
-                    msg, resp
+                lambda event, resp=response, mid=message_id: self._handle_acknowledge(
+                    mid, resp
                 ),
                 menu_item,
             )
@@ -136,12 +136,12 @@ class MessageView:
 
         menu.Destroy()
 
-    def _handle_acknowledge(self, message: CpdlcMessage, response: str):
+    def _handle_acknowledge(self, message_id: int, response: str):
         """Handle acknowledgement of a message.
 
         Args:
-            message: The message to acknowledge
+            message_id: The ID of the message to acknowledge
             response: The response text
         """
         if self.on_acknowledge:
-            self.on_acknowledge(message, response)
+            self.on_acknowledge(message_id, response)

--- a/src/model/cpdlc_session.py
+++ b/src/model/cpdlc_session.py
@@ -409,19 +409,34 @@ class CpdlcSession:
 
         return True, message
 
-    def handle_logon_accepted(self, station: str, mrn: Optional[int] = None) -> None:
+    def handle_logon_accepted(self, station: str, mrn: Optional[int] = None) -> bool:
         """Handle a LOGON ACCEPTED message from a station.
 
         Args:
             station: The station that accepted the logon
             mrn: The message reference number from the LOGON ACCEPTED message
+
+        Returns:
+            bool: True if the logon was accepted, False if it was ignored
         """
         # Validate station name is exactly 4 characters
         if len(station) != 4:
             self.logger.warning(
                 f"Invalid station name in LOGON ACCEPTED: {station} (must be 4 characters)"
             )
-            return
+            return False
+
+        # Validate the sender against our pending logon request. The MRN alone
+        # cannot do this: logon() restarts cpdlc_min_counter at 1, so every
+        # pending logon carries MIN 1 and a stale acceptance from a previously
+        # contacted station would match. Only checked when a logon is pending,
+        # so unsolicited acceptances during an automatic handover still apply.
+        if self.pending_logon_station and station != self.pending_logon_station:
+            self.logger.warning(
+                f"LOGON ACCEPTED from {station} does not match pending logon station "
+                f"{self.pending_logon_station}, ignoring"
+            )
+            return False
 
         # Validate MRN matches our pending logon request
         if self.pending_logon_min is not None and mrn is not None:
@@ -429,12 +444,13 @@ class CpdlcSession:
                 self.logger.warning(
                     f"LOGON ACCEPTED MRN {mrn} does not match pending logon MIN {self.pending_logon_min}, ignoring"
                 )
-                return
+                return False
 
         self.logger.info(f"Logon accepted by station: {station}")
         self.current_station = station
         self.pending_logon_min = None
         self.pending_logon_station = None
+        return True
 
     def handle_station_logoff(self, station: str) -> None:
         """Handle a LOGOFF message from a station.

--- a/src/model/message_manager.py
+++ b/src/model/message_manager.py
@@ -28,7 +28,12 @@ class MessageManager:
         self.logger = logger
         self.message_id_counter = 0
         self.message_log = {}  # Maps message_id to message object
-        self.acknowledged_messages = set()  # Set of (sender, message_id) tuples
+        # IDs of messages already responded to. Keyed on the ID this class
+        # assigns, not on (sender, MIN): MIN is the sending station's own
+        # counter, which restarts whenever that station re-logs on, so the
+        # same pair recurs within a single flight and would suppress the
+        # response options for a later, unrelated message.
+        self.acknowledged_messages = set()
 
     def add_message(self, message: HoppieMessage) -> int:
         """Add a HoppieMessage to the message log.
@@ -145,36 +150,32 @@ class MessageManager:
         else:
             return ""
 
-    def mark_acknowledged(self, message: CpdlcMessage):
+    def mark_acknowledged(self, message_id: int):
         """Mark a message as acknowledged.
 
         Args:
-            message: The CPDLC message that was acknowledged
+            message_id: The ID of the CPDLC message that was acknowledged
         """
-        if not isinstance(message, CpdlcMessage):
+        if not isinstance(self.message_log.get(message_id), CpdlcMessage):
             return
 
-        sender = message.get_from_name()
-        min_value = message.get_min()
-        message_key = (sender, min_value)
-        self.acknowledged_messages.add(message_key)
-        self.logger.debug(f"Marked message as acknowledged: {message_key}")
+        self.acknowledged_messages.add(message_id)
+        self.logger.debug(f"Marked message as acknowledged: ID={message_id}")
 
-    def needs_acknowledgement(self, message: HoppieMessage) -> Tuple[bool, List[str]]:
+    def needs_acknowledgement(self, message_id: int) -> Tuple[bool, List[str]]:
         """Check if a message needs acknowledgement and get valid responses.
 
         Args:
-            message: The message to check
+            message_id: The ID of the message to check
 
         Returns:
             tuple: (needs_ack, responses)
         """
-        if isinstance(message, CpdlcMessage):
-            # Create a message identifier tuple
-            message_key = (message.get_from_name(), message.get_min())
+        message = self.message_log.get(message_id)
 
+        if isinstance(message, CpdlcMessage):
             # Check if this message has already been acknowledged
-            if message_key not in self.acknowledged_messages:
+            if message_id not in self.acknowledged_messages:
                 responses = self._get_cpdlc_responses(message)
                 if responses:
                     self.logger.debug("Message needs acknowledgement.")

--- a/src/model/message_manager.py
+++ b/src/model/message_manager.py
@@ -1,7 +1,6 @@
 """Message management for the CPDLC client."""
 
-from typing import Dict, List, Tuple, Set, Optional, Any, Callable
-import logging
+from typing import List, Tuple, Set, Optional, Any
 
 from hoppie_connector import (
     CpdlcMessage,
@@ -14,6 +13,30 @@ from src.utils.message_formatting import (
     format_list_text,
     format_message_text,
 )
+
+# The responses a pilot may send for each response requirement, in the order
+# they are offered in the context menu. Requirements that need no reply
+# (RR.NO, RR.NOT_REQUIRED) are absent by design.
+RESPONSES_BY_REQUIREMENT = {
+    RR.WILCO_UNABLE: ["WILCO", "UNABLE", "STANDBY"],
+    RR.AFFIRM_NEGATIVE: ["AFFIRM", "NEGATIVE", "STANDBY"],
+    RR.ROGER: ["ROGER", "STANDBY"],
+    RR.YES: ["YES", "NO"],
+}
+
+# Every response string the client can send, derived from the table above so
+# the two cannot drift. The polling controller imports this rather than
+# keeping its own copy.
+CPDLC_RESPONSES = frozenset(
+    response
+    for responses in RESPONSES_BY_REQUIREMENT.values()
+    for response in responses
+)
+
+# Responses that do NOT answer a message for good. STANDBY tells the controller
+# to wait; the pilot must still follow it with WILCO/UNABLE, so it must not
+# retire the response options.
+NON_TERMINAL_RESPONSES = frozenset({"STANDBY"})
 
 
 class MessageManager:
@@ -28,12 +51,15 @@ class MessageManager:
         self.logger = logger
         self.message_id_counter = 0
         self.message_log = {}  # Maps message_id to message object
-        # IDs of messages already responded to. Keyed on the ID this class
-        # assigns, not on (sender, MIN): MIN is the sending station's own
-        # counter, which restarts whenever that station re-logs on, so the
-        # same pair recurs within a single flight and would suppress the
-        # response options for a later, unrelated message.
-        self.acknowledged_messages = set()
+        # IDs of messages that have been answered for good. This is not "every
+        # message a response was sent for": STANDBY is transmitted but stays
+        # out of this set, so the message remains answerable.
+        #
+        # Keyed on the ID this class assigns, not on (sender, MIN): MIN is the
+        # sending station's own counter, which restarts whenever that station
+        # re-logs on, so the same pair recurs within a single flight and would
+        # suppress the response options for a later, unrelated message.
+        self.acknowledged_messages: Set[int] = set()
 
     def add_message(self, message: HoppieMessage) -> int:
         """Add a HoppieMessage to the message log.
@@ -91,6 +117,25 @@ class MessageManager:
             The message object or None if not found
         """
         return self.message_log.get(message_id)
+
+    def get_cpdlc_addressing(self, message_id: int) -> Optional[Tuple[str, int]]:
+        """Get the sender and MIN needed to address a reply to a message.
+
+        Saves the caller from reaching into CpdlcMessage itself, and gives it a
+        single check for "this ID cannot be replied to".
+
+        Args:
+            message_id: The message ID
+
+        Returns:
+            tuple: (sender, min_value), or None if the ID does not name a CPDLC
+                message
+        """
+        message = self.message_log.get(message_id)
+        if not isinstance(message, CpdlcMessage):
+            return None
+
+        return message.get_from_name(), message.get_min()
 
     def get_message_display_text(self, message_id: int) -> Tuple[str, str]:
         """Get formatted display text for a message.
@@ -150,23 +195,35 @@ class MessageManager:
         else:
             return ""
 
-    def mark_acknowledged(self, message_id: int):
-        """Mark a message as acknowledged.
+    def mark_acknowledged(self, message_id: int, response: str):
+        """Record the response that was sent for a message.
+
+        Non-terminal responses are transmitted but leave the message
+        answerable, so they are not recorded here.
 
         Args:
-            message_id: The ID of the CPDLC message that was acknowledged
+            message_id: The ID of the CPDLC message that was responded to
+            response: The response text that was sent
         """
-        if not isinstance(self.message_log.get(message_id), CpdlcMessage):
+        if response.strip().upper() in NON_TERMINAL_RESPONSES:
+            self.logger.debug(
+                f"Response {response} does not retire message ID={message_id}"
+            )
             return
 
         self.acknowledged_messages.add(message_id)
         self.logger.debug(f"Marked message as acknowledged: ID={message_id}")
 
-    def needs_acknowledgement(self, message_id: int) -> Tuple[bool, List[str]]:
+    def needs_acknowledgement(
+        self, message_id: int, current_station: str
+    ) -> Tuple[bool, List[str]]:
         """Check if a message needs acknowledgement and get valid responses.
 
         Args:
             message_id: The ID of the message to check
+            current_station: The station currently logged on. Messages from any
+                other station are no longer part of the live dialogue and
+                cannot be answered.
 
         Returns:
             tuple: (needs_ack, responses)
@@ -174,6 +231,14 @@ class MessageManager:
         message = self.message_log.get(message_id)
 
         if isinstance(message, CpdlcMessage):
+            sender = message.get_from_name()
+            if sender != current_station:
+                self.logger.debug(
+                    f"Message ID={message_id} is from {sender}, not the current "
+                    f"station {current_station or '(none)'}; not answerable."
+                )
+                return False, []
+
             # Check if this message has already been acknowledged
             if message_id not in self.acknowledged_messages:
                 responses = self._get_cpdlc_responses(message)
@@ -191,30 +256,12 @@ class MessageManager:
             message: The CPDLC message
 
         Returns:
-            list: Valid response strings
+            list: Valid response strings, empty if the message needs no reply
         """
-        responses = []
-        rr = message.get_rr()
-        if rr == RR.W_U:
-            responses.append("WILCO")
-            responses.append("UNABLE")
-            responses.append("STANDBY")
-        elif rr == RR.A_N:
-            responses.append("AFFIRM")
-            responses.append("NEGATIVE")
-            responses.append("STANDBY")
-        elif rr == RR.R:
-            responses.append("ROGER")
-            responses.append("STANDBY")
-        elif rr == RR.YES:
-            responses.append("YES")
-            responses.append("NO")
-        elif rr == RR.NO:
-            # N means "no response required" (used on response messages)
-            return []
-        else:
+        responses = RESPONSES_BY_REQUIREMENT.get(message.get_rr())
+        if not responses:
             self.logger.debug("No responses needed.")
             return []
 
         self.logger.debug(f"Valid responses: {responses}")
-        return responses
+        return list(responses)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,84 @@
+"""Shared fixtures for the sim-cpdlc test suite."""
+
+import logging
+
+import pytest
+from hoppie_connector import CpdlcMessage, CpdlcResponseRequirement as RR
+
+CLIENT_CALLSIGN = "DLH123"
+
+
+@pytest.fixture
+def logger():
+    """A real logger that discards output, so log calls are exercised but silent."""
+    log = logging.getLogger("sim-cpdlc-tests")
+    log.handlers = [logging.NullHandler()]
+    log.propagate = False
+    return log
+
+
+def uplink(sender, min_value, text="CLIMB TO AND MAINTAIN FL360", rr=RR.WILCO_UNABLE):
+    """Build an uplink CpdlcMessage as it would arrive from a station."""
+    return CpdlcMessage(sender, CLIENT_CALLSIGN, min_value, rr, text)
+
+
+class FakeConnectionManager:
+    """Stands in for ConnectionManager, recording frames instead of transmitting.
+
+    ConnectionManager is the network boundary and is injected into CpdlcSession,
+    so this is the intended seam rather than a mock of code under test.
+    """
+
+    def __init__(self, connected=True):
+        self._connected = connected
+        self.sent = []
+
+    def is_connected(self):
+        return self._connected
+
+    def send_cpdlc(self, recipient, min_value, response_type, message, mrn=None):
+        self.sent.append((recipient, min_value, response_type, message, mrn))
+
+
+class RecordingMessageView:
+    """Captures the message IDs the window pushes into the list view."""
+
+    def __init__(self):
+        self.added = []
+
+    def add_message(self, message_id):
+        self.added.append(message_id)
+
+
+class FakePollingController:
+    """Records polling-rate changes without owning a wx.Timer."""
+
+    def __init__(self):
+        self.active_calls = 0
+
+    def set_active_polling(self):
+        self.active_calls += 1
+
+
+def make_main_window(logger, cpdlc_session, message_manager):
+    """Build a MainWindow whose wx.Frame half is never initialised.
+
+    MainWindow.__init__ opens dialogs, loads sounds and starts an update check,
+    none of which a unit test should trigger. Allocating the instance and wiring
+    only the collaborators the message path touches lets the real
+    _on_message_received / _on_acknowledge_message code run unmodified.
+    """
+    from src.gui.main_window import MainWindow
+
+    window = MainWindow.__new__(MainWindow)
+    window.logger = logger
+    window.cpdlc_session = cpdlc_session
+    window.message_manager = message_manager
+    window.message_view = RecordingMessageView()
+    window.polling_controller = FakePollingController()
+    window.new_message_sound = None
+    window.status_texts = []
+    # Instance attribute shadows wx.Frame.SetStatusText, which would need a
+    # live C++ frame behind it.
+    window.SetStatusText = window.status_texts.append
+    return window

--- a/tests/test_acknowledge_path.py
+++ b/tests/test_acknowledge_path.py
@@ -1,0 +1,65 @@
+"""End-to-end tests for the acknowledgement path through MainWindow."""
+
+from conftest import FakeConnectionManager, make_main_window, uplink
+
+from src.model.cpdlc_session import CpdlcSession
+from src.model.message_manager import MessageManager
+
+STATION = "LSAG"
+
+
+def build(logger):
+    connection = FakeConnectionManager()
+    session = CpdlcSession(logger, connection)
+    session.set_callsign("DLH123")
+    session.handle_logon_accepted(STATION)
+    manager = MessageManager(logger)
+    window = make_main_window(logger, session, manager)
+    return window, manager, connection
+
+
+def test_wilco_is_sent_with_the_senders_own_min_as_mrn(logger):
+    window, manager, connection = build(logger)
+    message_id = manager.add_message(uplink(STATION, 53))
+
+    window._on_acknowledge_message(message_id, "WILCO")
+
+    recipient, _own_min, _rr, text, mrn = connection.sent[-1]
+    assert (recipient, text, mrn) == (STATION, "WILCO", 53)
+
+
+def test_wilco_retires_the_message(logger):
+    window, manager, _ = build(logger)
+    message_id = manager.add_message(uplink(STATION, 53))
+
+    window._on_acknowledge_message(message_id, "WILCO")
+
+    assert manager.needs_acknowledgement(message_id, STATION) == (False, [])
+
+
+def test_standby_is_sent_but_leaves_the_message_answerable(logger):
+    window, manager, connection = build(logger)
+    message_id = manager.add_message(uplink(STATION, 53))
+
+    window._on_acknowledge_message(message_id, "STANDBY")
+
+    assert connection.sent[-1][3] == "STANDBY"
+    assert manager.needs_acknowledgement(message_id, STATION)[0] is True
+
+
+def test_an_unknown_id_sends_nothing_and_tells_the_user(logger):
+    window, _manager, connection = build(logger)
+
+    window._on_acknowledge_message(4242, "WILCO")
+
+    assert connection.sent == []
+    assert window.status_texts != []
+
+
+def test_a_custom_message_id_sends_nothing_and_does_not_raise(logger):
+    window, manager, connection = build(logger)
+    message_id = manager.add_custom_message("Connected as DLH123", "SYSTEM")
+
+    window._on_acknowledge_message(message_id, "WILCO")
+
+    assert connection.sent == []

--- a/tests/test_cpdlc_session.py
+++ b/tests/test_cpdlc_session.py
@@ -1,0 +1,49 @@
+"""Tests for CPDLC session state, especially logon acceptance validation."""
+
+from conftest import FakeConnectionManager
+from src.model.cpdlc_session import CpdlcSession
+
+
+def test_logon_accepted_from_a_station_other_than_the_pending_one_is_rejected(logger):
+    """A stale station must not be able to claim a logon we requested elsewhere.
+
+    Each logon() resets cpdlc_min_counter to 1, so every pending logon carries
+    MIN 1 and the MRN alone cannot distinguish which station we asked.
+    """
+    session = CpdlcSession(logger, FakeConnectionManager())
+    session.logon("EDGG")
+    session.logon("EDDF")
+
+    accepted = session.handle_logon_accepted("EDGG", mrn=1)
+
+    assert accepted is False
+    assert session.get_current_station() == ""
+
+
+def test_logon_accepted_from_the_pending_station_is_accepted(logger):
+    session = CpdlcSession(logger, FakeConnectionManager())
+    session.logon("EDDF")
+
+    accepted = session.handle_logon_accepted("EDDF", mrn=1)
+
+    assert accepted is True
+    assert session.get_current_station() == "EDDF"
+
+
+def test_unsolicited_logon_accepted_is_still_honoured(logger):
+    """Automatic handovers arrive with no pending logon; that path must keep working."""
+    session = CpdlcSession(logger, FakeConnectionManager())
+
+    accepted = session.handle_logon_accepted("EDUU", mrn=None)
+
+    assert accepted is True
+    assert session.get_current_station() == "EDUU"
+
+
+def test_logon_accepted_with_invalid_station_name_is_rejected(logger):
+    session = CpdlcSession(logger, FakeConnectionManager())
+
+    accepted = session.handle_logon_accepted("TOOLONG", mrn=None)
+
+    assert accepted is False
+    assert session.get_current_station() == ""

--- a/tests/test_logon_status.py
+++ b/tests/test_logon_status.py
@@ -1,0 +1,39 @@
+"""The status bar must not report a logon the session model refused.
+
+README.md documents the status bar as the surface screen-reader users query
+with NVDA+End, so a false 'Logged on to X' is the one message a blind pilot
+cannot cross-check.
+"""
+
+from conftest import FakeConnectionManager, make_main_window, uplink
+from hoppie_connector import CpdlcResponseRequirement as RR
+
+from src.model.cpdlc_session import CpdlcSession
+from src.model.message_manager import MessageManager
+
+
+def _logon_accepted_from(station, mrn):
+    return uplink(station, mrn, text="LOGON ACCEPTED", rr=RR.NOT_REQUIRED)
+
+
+def test_status_bar_is_silent_when_logon_acceptance_is_rejected(logger):
+    session = CpdlcSession(logger, FakeConnectionManager())
+    session.logon("EDGG")
+    session.logon("EDDF")
+    window = make_main_window(logger, session, MessageManager(logger))
+
+    window._on_message_received(_logon_accepted_from("EDGG", 1))
+
+    assert window.status_texts == []
+    assert session.get_current_station() == ""
+
+
+def test_status_bar_reports_an_accepted_logon(logger):
+    session = CpdlcSession(logger, FakeConnectionManager())
+    session.logon("EDDF")
+    window = make_main_window(logger, session, MessageManager(logger))
+
+    window._on_message_received(_logon_accepted_from("EDDF", 1))
+
+    assert window.status_texts == ["Logged on to EDDF."]
+    assert session.get_current_station() == "EDDF"

--- a/tests/test_main_window_wiring.py
+++ b/tests/test_main_window_wiring.py
@@ -1,0 +1,60 @@
+"""Integration test for the real MainWindow._init_ui wiring.
+
+MainWindow.__init__ opens dialogs, loads a sound and starts an update check.
+This subclass runs the genuine _init_ui (and _init_menu) on a real frame with
+only the collaborators those methods need, so a mis-wired MessageView is caught
+here rather than at application startup.
+"""
+
+import pytest
+import wx
+
+from conftest import FakeConnectionManager, uplink
+from src.gui.main_window import MainWindow
+from src.model.cpdlc_session import CpdlcSession
+from src.model.message_manager import MessageManager
+
+STATION = "LSAG"
+
+
+class HeadlessMainWindow(MainWindow):
+    def __init__(self, logger, cpdlc_session, message_manager):
+        wx.Frame.__init__(self, None, title="Sim-CPDLC test")
+        self.logger = logger
+        self.cpdlc_session = cpdlc_session
+        self.message_manager = message_manager
+        self._init_ui()
+
+
+@pytest.fixture
+def window(logger):
+    app = wx.App()
+    session = CpdlcSession(logger, FakeConnectionManager())
+    frame = HeadlessMainWindow(logger, session, MessageManager(logger))
+    yield frame
+    frame.Destroy()
+    app.Destroy()
+
+
+def test_init_ui_wires_the_message_view_to_the_live_session(window):
+    """The view must read the station from the session, not a stale copy."""
+    window.cpdlc_session.handle_logon_accepted(STATION)
+
+    assert window.message_view.get_current_station() == STATION
+
+
+def test_context_menu_follows_the_session_after_a_handover(window):
+    """A message from the station we have left stops offering responses."""
+    window.cpdlc_session.handle_logon_accepted("EDYY")
+    message_id = window.message_manager.add_message(uplink("EDYY", 4))
+    window.message_view.add_message(message_id)
+    window.message_view.message_list.Select(0)
+    station = window.message_view.get_current_station()
+
+    assert window.message_manager.needs_acknowledgement(message_id, station)[0] is True
+
+    window.cpdlc_session.handle_station_logoff("EDYY")
+    window.cpdlc_session.handle_logon_accepted("EDGG")
+    station = window.message_view.get_current_station()
+
+    assert window.message_manager.needs_acknowledgement(message_id, station)[0] is False

--- a/tests/test_message_manager.py
+++ b/tests/test_message_manager.py
@@ -1,0 +1,115 @@
+"""Tests for message identity, acknowledgement state and response options."""
+
+from conftest import uplink
+from hoppie_connector import CpdlcResponseRequirement as RR
+
+from src.model.message_manager import MessageManager
+
+STATION = "LSAG"
+
+
+def test_a_reused_min_does_not_suppress_a_later_message(logger):
+    """Regression test for the bug this branch fixes.
+
+    MIN is the sending station's own counter and restarts when that station
+    re-logs on, so the same (sender, MIN) pair recurs within one flight. Keying
+    acknowledgements on it made the second instruction unanswerable.
+    """
+    manager = MessageManager(logger)
+    climb = manager.add_message(uplink(STATION, 53, "CLIMB TO AND MAINTAIN FL360"))
+    manager.mark_acknowledged(climb, "WILCO")
+
+    contact = manager.add_message(uplink(STATION, 53, "CONTACT MARSEILLE CONTROL"))
+
+    needs_ack, responses = manager.needs_acknowledgement(contact, STATION)
+    assert needs_ack is True
+    assert responses == ["WILCO", "UNABLE", "STANDBY"]
+
+
+def test_acknowledging_one_message_does_not_answer_the_other(logger):
+    manager = MessageManager(logger)
+    climb = manager.add_message(uplink(STATION, 53, "CLIMB TO AND MAINTAIN FL360"))
+    manager.mark_acknowledged(climb, "WILCO")
+
+    assert manager.needs_acknowledgement(climb, STATION) == (False, [])
+
+
+def test_standby_leaves_the_message_answerable(logger):
+    """The one behaviour that must not regress: STANDBY is not a final answer."""
+    manager = MessageManager(logger)
+    message_id = manager.add_message(uplink(STATION, 7))
+
+    manager.mark_acknowledged(message_id, "STANDBY")
+
+    needs_ack, responses = manager.needs_acknowledgement(message_id, STATION)
+    assert needs_ack is True
+    assert responses == ["WILCO", "UNABLE", "STANDBY"]
+
+
+def test_standby_is_recognised_regardless_of_case(logger):
+    manager = MessageManager(logger)
+    message_id = manager.add_message(uplink(STATION, 7))
+
+    manager.mark_acknowledged(message_id, "standby")
+
+    assert manager.needs_acknowledgement(message_id, STATION)[0] is True
+
+
+def test_a_message_from_another_station_offers_no_responses(logger):
+    """After a handover the old station's messages are no longer answerable."""
+    manager = MessageManager(logger)
+    message_id = manager.add_message(uplink("EDYY", 4))
+
+    assert manager.needs_acknowledgement(message_id, "EDGG") == (False, [])
+
+
+def test_a_message_offers_no_responses_when_not_logged_on(logger):
+    manager = MessageManager(logger)
+    message_id = manager.add_message(uplink("EDYY", 4))
+
+    assert manager.needs_acknowledgement(message_id, "") == (False, [])
+
+
+def test_get_cpdlc_addressing_returns_sender_and_min(logger):
+    manager = MessageManager(logger)
+    message_id = manager.add_message(uplink(STATION, 53))
+
+    assert manager.get_cpdlc_addressing(message_id) == (STATION, 53)
+
+
+def test_get_cpdlc_addressing_rejects_a_custom_message(logger):
+    manager = MessageManager(logger)
+    message_id = manager.add_custom_message("Connected as DLH123", "SYSTEM")
+
+    assert manager.get_cpdlc_addressing(message_id) is None
+
+
+def test_get_cpdlc_addressing_rejects_an_unknown_id(logger):
+    manager = MessageManager(logger)
+
+    assert manager.get_cpdlc_addressing(4242) is None
+
+
+def test_a_roger_message_offers_roger_and_standby(logger):
+    manager = MessageManager(logger)
+    message_id = manager.add_message(uplink(STATION, 9, "ALTIMETER 1013", rr=RR.ROGER))
+
+    assert manager.needs_acknowledgement(message_id, STATION) == (
+        True,
+        ["ROGER", "STANDBY"],
+    )
+
+
+def test_a_message_needing_no_response_offers_none(logger):
+    manager = MessageManager(logger)
+    message_id = manager.add_message(
+        uplink(STATION, 10, "LOGON ACCEPTED", rr=RR.NOT_REQUIRED)
+    )
+
+    assert manager.needs_acknowledgement(message_id, STATION) == (False, [])
+
+
+def test_marking_an_unknown_id_is_harmless(logger):
+    manager = MessageManager(logger)
+
+    manager.mark_acknowledged(4242, "WILCO")  # must not raise

--- a/tests/test_message_view.py
+++ b/tests/test_message_view.py
@@ -1,0 +1,61 @@
+"""Tests for the message list view and its response context menu."""
+
+import pytest
+import wx
+
+from conftest import uplink
+from src.gui.message_view import MessageView
+from src.model.message_manager import MessageManager
+
+STATION = "LSAG"
+
+
+@pytest.fixture
+def panel():
+    app = wx.App()
+    frame = wx.Frame(None)
+    yield wx.Panel(frame)
+    frame.Destroy()
+    app.Destroy()
+
+
+def build_view(panel, logger, manager, station):
+    view = MessageView(
+        panel, logger, manager, lambda *_: None, lambda: station
+    )
+    # PopupMenu runs a nested modal loop, which would hang the test. Shadowing
+    # it records that a menu would have been shown.
+    panel.popped = []
+    panel.PopupMenu = panel.popped.append
+    return view
+
+
+def test_message_list_is_single_selection(panel, logger):
+    """GetFirstSelected is only unambiguous when one row can be selected."""
+    view = MessageView(panel, logger, MessageManager(logger), None, lambda: "")
+
+    assert view.message_list.GetWindowStyleFlag() & wx.LC_SINGLE_SEL
+
+
+def test_no_menu_for_a_message_from_another_station(panel, logger):
+    manager = MessageManager(logger)
+    view = build_view(panel, logger, manager, "EDGG")
+    message_id = manager.add_message(uplink("EDYY", 4))
+    view.add_message(message_id)
+    view.message_list.Select(0)
+
+    view.on_context_menu(None)
+
+    assert panel.popped == []
+
+
+def test_menu_shown_for_a_message_from_the_current_station(panel, logger):
+    manager = MessageManager(logger)
+    view = build_view(panel, logger, manager, STATION)
+    message_id = manager.add_message(uplink(STATION, 4))
+    view.add_message(message_id)
+    view.message_list.Select(0)
+
+    view.on_context_menu(None)
+
+    assert len(panel.popped) == 1

--- a/tests/test_polling_controller.py
+++ b/tests/test_polling_controller.py
@@ -1,0 +1,28 @@
+"""Tests for polling-rate decisions."""
+
+from conftest import uplink
+from hoppie_connector import CpdlcResponseRequirement as RR
+
+from src.controller.polling_controller import PollingController
+from src.model.message_manager import CPDLC_RESPONSES
+
+
+def controller(logger):
+    return PollingController(logger, connection_manager=None)
+
+
+def test_a_bare_acknowledgement_does_not_speed_up_polling(logger):
+    """Every response the client can send counts as an acknowledgement."""
+    poller = controller(logger)
+
+    for response in sorted(CPDLC_RESPONSES):
+        message = uplink("LSAG", 1, response, rr=RR.NO)
+        assert poller.should_increase_polling_rate(message) is False, response
+
+
+def test_a_clearance_speeds_up_polling(logger):
+    poller = controller(logger)
+
+    message = uplink("LSAG", 1, "CLIMB TO AND MAINTAIN FL360")
+
+    assert poller.should_increase_polling_rate(message) is True


### PR DESCRIPTION
Fixes a bug where, part way through a flight, a clearance that should offer WILCO offers nothing at all — no context menu, no response options — leaving it impossible to acknowledge. It looks random, because whether it happens depends on which message numbers have come up earlier.

## Cause

Acknowledgements are tracked in `MessageManager.acknowledged_messages` as `(sender, MIN)` tuples, and that set is never cleared for the lifetime of the process — not on logon, logoff or disconnect.

MIN is the *sending station's* own message counter. It is small, and it restarts from 1 whenever that station re-logs on. So the same `(sender, MIN)` pair recurs within a single flight, and once one has been acknowledged, `needs_acknowledgement()` treats every later message carrying that pair as already answered and returns no responses.

## Evidence

I went through a log covering 39 app runs and 188 WILCO-requiring uplinks, and found **nine collisions inside a single run** — each a genuinely different instruction reusing a MIN, not a duplicate delivery:

```
LSAG MIN 53:
    20:44:32  CLIMB TO AND MAINTAIN FL360
    20:48:32  CONTACT MARSEILLE CONTROL ON @128.325@.

KUSA MIN 34:
    18:55:00  CLRD TO @EGLL@. RADAR VECTORS TO @DEEZZ@. MNTN @5000@...
    20:27:22  CONTACT CLEVELAND CENTER ON @119.375@.

CZQM MIN 35:
    19:31:34  CONTACT GANDER CENTER ON @135.05@.
    19:59:36  CONTACT GANDER CENTER ON @133.0@.
```

In the LSAG case, after WILCOing the climb, the frequency change four minutes later could not be acknowledged at all.

## Fix

Key acknowledgements on the message ID `MessageManager` already assigns, which is unique per received message. A reused MIN then cannot suppress a later message.

`needs_acknowledgement()` and `mark_acknowledged()` take that ID instead of the message object. Both callers already had it to hand — `MessageView.on_context_menu()` reads it from the list item, and it is threaded through `_handle_acknowledge` to `MainWindow._on_acknowledge_message`, which looks the message up when it needs the sender and MIN to send the response.

Three files, +30/-24.

## Verification

Reproduced with the real LSAG packets from the log, run against this branch and against `main`.

On `main`:

```
1. CLIMB TO FL360      (LSAG MIN 53) -> needs_ack=True ['WILCO', 'UNABLE', 'STANDBY']
2. after the pilot WILCOs it         -> needs_ack=False
3. CONTACT MARSEILLE   (LSAG MIN 53) -> needs_ack=False []

BUG REPRODUCED: the new instruction offers no WILCO.
```

On this branch:

```
1. CLIMB TO FL360      (LSAG MIN 53) -> needs_ack=True ['WILCO', 'UNABLE', 'STANDBY']
2. after the pilot WILCOs it         -> needs_ack=False
3. CONTACT MARSEILLE   (LSAG MIN 53) -> needs_ack=True ['WILCO', 'UNABLE', 'STANDBY']

PASS: the reused MIN no longer suppresses the new instruction.
      and the two are acknowledged independently.
```

Also checked through the real call chain by building `MainWindow` and driving `MessageView._handle_acknowledge`:

- the acknowledgement still goes out with the correct sender and MIN (`('LSAG', 53, 'WILCO')`)
- the acknowledged message stops offering responses
- a different message reusing MIN 53 still offers them
- **STANDBY still leaves the message answerable**, which is the one behaviour that must not regress

## Note on overlap

This touches the same three files as #24. They are independent changes and either can go first; I'm happy to rebase whichever you merge second so you don't have to resolve it. #24 also adds a test suite that would be a natural home for a regression test for this.
