### PR TITLE
Stop HTTP errors making requests silently do nothing

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,11 +5,75 @@ Sim-CPDLC - A simple CPDLC client for SayIntentions.ai
 This is the main entry point for the application.
 """
 
+import sys
+import threading
+import traceback
+
 import wx
 
 from src.logging_setup import setup_logging
 from src.gui import MainWindow
 from src.config import get_user_data_dir
+from src.model.connection_manager import install_request_timeout
+
+
+def _install_exception_handlers(logger):
+    """Route otherwise-unhandled exceptions to the log and to the user.
+
+    wxPython discards exceptions raised inside event handlers, and the packaged
+    build runs with console=False so stderr goes nowhere. Without a last-resort
+    handler a failing handler looks exactly like a button that does nothing.
+
+    Args:
+        logger: Application logger
+    """
+
+    def show_dialog(text):
+        try:
+            wx.MessageBox(text, "Unexpected Error", wx.OK | wx.ICON_ERROR)
+        except Exception:
+            # Never let the reporter itself take the application down.
+            logger.exception("Failed to display the unhandled-exception dialog")
+
+    def report(exc_type, exc_value, exc_tb, source):
+        logger.error(
+            f"Unhandled exception in {source}: {exc_type.__name__}: {exc_value}\n"
+            + "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
+        )
+        text = (
+            f"An unexpected error occurred:\n\n{exc_type.__name__}: {exc_value}\n\n"
+            "The details have been written to the log file."
+        )
+        if wx.IsMainThread():
+            show_dialog(text)
+        else:
+            # wx widgets may only be touched from the GUI thread.
+            wx.CallAfter(show_dialog, text)
+
+    def handle_uncaught(exc_type, exc_value, exc_tb):
+        if issubclass(exc_type, KeyboardInterrupt):
+            sys.__excepthook__(exc_type, exc_value, exc_tb)
+            return
+        report(exc_type, exc_value, exc_tb, "main thread")
+
+    def handle_thread(args):
+        report(args.exc_type, args.exc_value, args.exc_traceback, "background thread")
+
+    sys.excepthook = handle_uncaught
+    threading.excepthook = handle_thread
+
+
+class SimCpdlcApp(wx.App):
+    """wx.App that reports exceptions escaping an event handler."""
+
+    def __init__(self, logger):
+        self.logger = logger
+        super().__init__(False)
+
+    def OnExceptionInMainLoop(self):
+        """Log and show any exception raised inside a wx event handler."""
+        sys.excepthook(*sys.exc_info())
+        return True
 
 
 def main():
@@ -22,8 +86,15 @@ def main():
     user_data_dir = get_user_data_dir()
     logger.info(f"Using user data directory: {user_data_dir}")
 
+    _install_exception_handlers(logger)
+
+    # hoppie_connector passes no timeout to requests, so a server that accepts
+    # the connection and then goes silent would otherwise block the GUI thread
+    # forever. This gives those calls a default timeout.
+    install_request_timeout()
+
     # Create and start the application
-    app = wx.App(False)
+    app = SimCpdlcApp(logger)
     frame = MainWindow(None, "Sim-CPDLC", logger)
 
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-hoppie-connector==0.2.0
+hoppie-connector==0.2.1
 pyinstaller==6.19.0
 requests==2.32.5
 wxPython==4.2.5
 appdirs==1.4.4
-packaging==26.0
+packaging==26.2
 SimConnect>=0.4.26

--- a/src/config.py
+++ b/src/config.py
@@ -92,8 +92,10 @@ def save_config(config):
 
 
 # API URLs
-SAYINTENTIONS_API_URL = "http://acars.sayintentions.ai/acars/system/connect.html"
-HOPPIE_API_URL = "http://www.hoppie.nl/acars/system/connect.html"
+# HTTPS is required: the logon code travels as a query parameter on every
+# request, so plain HTTP would expose it to anyone on the same network.
+SAYINTENTIONS_API_URL = "https://acars.sayintentions.ai/acars/system/connect.html"
+HOPPIE_API_URL = "https://www.hoppie.nl/acars/system/connect.html"
 
 # Polling configuration (in milliseconds)
 DEFAULT_POLL_INTERVAL = 60000  # 60 seconds
@@ -102,6 +104,11 @@ INACTIVITY_TIMEOUT = 300000  # 5 minutes
 
 # Maximum connection failures before attempting reconnection
 MAX_CONNECTION_FAILURES = 3
+
+# Network timeout in seconds, applied to every outbound ACARS request.
+# hoppie_connector sets no timeout of its own, so without this a server that
+# accepts the connection and then stops responding would block forever.
+NETWORK_TIMEOUT = 15
 
 # Sound file path
 MESSAGE_SOUND_FILENAME = "message.wav"

--- a/src/controller/polling_controller.py
+++ b/src/controller/polling_controller.py
@@ -39,6 +39,8 @@ class PollingController:
         self.inactivity_timeout = inactivity_timeout
         self.last_activity_time = 0
         self.poll_timer = None
+        self.parent_window = None
+        self._reported_failure = False
 
     def start(self, parent_window):
         """Start the polling timer.
@@ -46,6 +48,7 @@ class PollingController:
         Args:
             parent_window: The parent window for the timer
         """
+        self.parent_window = parent_window
         self.poll_timer = wx.Timer(parent_window)
         parent_window.Bind(wx.EVT_TIMER, self.on_poll_timer, self.poll_timer)
         self.poll_timer.Start(self.default_poll_interval)
@@ -80,6 +83,10 @@ class PollingController:
             self.logger.error(f"Unexpected error during poll: {e}")
             return
 
+        # Surface link state: a failing poll is otherwise invisible, leaving the
+        # status bar reading "Connected" through a total outage.
+        self._report_connection_state()
+
         # Process received messages
         if messages:
             self.logger.info(f"Received {len(messages)} new message(s)")
@@ -103,11 +110,36 @@ class PollingController:
             success = self.connection_manager.attempt_reconnection()
             if success:
                 self.logger.info("Reconnection successful")
+                self._set_status("Reconnected.")
                 # Restart the poll timer if it's not running
                 if not self.is_running():
                     self.poll_timer.Start(self.default_poll_interval)
             else:
                 self.logger.error("Reconnection failed")
+                self._set_status("Connection lost. Reconnect to continue.")
+                # attempt_reconnection() cleared cnx, so the next tick would
+                # stop the timer and nothing would ever restart it. Stop here
+                # and let the user reconnect deliberately.
+                self.stop()
+
+    def _set_status(self, text):
+        """Show a short connection message in the parent window's status bar."""
+        if self.parent_window and hasattr(self.parent_window, "SetStatusText"):
+            self.parent_window.SetStatusText(text)
+
+    def _report_connection_state(self):
+        """Tell the user when polling starts failing, and when it recovers."""
+        failing = self.connection_manager.poll_failed()
+        if failing:
+            self._reported_failure = True
+            self._set_status(
+                f"Connection problem "
+                f"({self.connection_manager.failure_count()}/"
+                f"{self.connection_manager.max_connection_failures}) - retrying..."
+            )
+        elif self._reported_failure:
+            self._reported_failure = False
+            self._set_status("Connection restored.")
 
     def set_active_polling(self):
         """Switch to more frequent polling during active communication."""

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -14,12 +14,9 @@ from hoppie_connector import (
 )
 
 from src.config import (
-    SAYINTENTIONS_API_URL,
-    HOPPIE_API_URL,
     DEFAULT_POLL_INTERVAL,
     ACTIVE_POLL_INTERVAL,
     INACTIVITY_TIMEOUT,
-    MAX_CONNECTION_FAILURES,
     MESSAGE_SOUND_FILENAME,
     load_config,
     save_config,

--- a/src/model/connection_manager.py
+++ b/src/model/connection_manager.py
@@ -1,47 +1,94 @@
 """Connection management for the CPDLC client."""
 
-import logging
-import wx
+import functools
+import re
+
 import requests
 
 from hoppie_connector import HoppieConnector, HoppieError
 
-from src.config import SAYINTENTIONS_API_URL, HOPPIE_API_URL
+from src.config import (
+    SAYINTENTIONS_API_URL,
+    HOPPIE_API_URL,
+    MAX_CONNECTION_FAILURES,
+    NETWORK_TIMEOUT,
+)
+
+
+# Transport failures worth retrying. The builtin ConnectionError is what
+# hoppie_connector raises for a non-OK HTTP status; requests' own hierarchy
+# covers timeouts and DNS failures. Deliberately narrower than OSError, which
+# would also swallow local faults such as a missing CA bundle in a packaged
+# build and misreport them as a network outage.
+TRANSPORT_ERRORS = (ConnectionError, TimeoutError, requests.RequestException)
+
+# Input and response-parsing failures. hoppie_connector raises these bare, so
+# without converting them a too-long telex or a proxy's HTML error page would
+# escape every `except HoppieError` and vanish into the wx event loop.
+PROTOCOL_ERRORS = (ValueError, TypeError)
+
+_LOGON_PATTERN = re.compile(r"(logon=)[^&\s]+", re.IGNORECASE)
+_SERVER_INFO_PATTERN = re.compile(r"^\{server info \{(.+)\}\}$", re.DOTALL)
+
+
+def install_request_timeout(timeout=NETWORK_TIMEOUT):
+    """Give requests a default timeout for callers that omit one.
+
+    hoppie_connector calls requests.get/post with no timeout and offers no hook
+    to supply one, so a server that accepts the connection and then goes silent
+    would block the GUI thread forever. socket.setdefaulttimeout() does not help
+    here: requests explicitly calls sock.settimeout(None) when no timeout is
+    given, which overrides the global default.
+
+    Args:
+        timeout: Default timeout in seconds for calls that specify none
+    """
+    for name in ("get", "post"):
+        original = getattr(requests, name)
+        if getattr(original, "_default_timeout_applied", False):
+            continue
+
+        @functools.wraps(original)
+        def wrapper(*args, _original=original, **kwargs):
+            kwargs.setdefault("timeout", timeout)
+            return _original(*args, **kwargs)
+
+        wrapper._default_timeout_applied = True
+        setattr(requests, name, wrapper)
+
+
+def redact(text):
+    """Strip logon codes out of text destined for a log file or a dialog.
+
+    requests embeds the full request URL in its exception messages, and that
+    URL carries the logon code as a query parameter.
+
+    Args:
+        text: The text to scrub
+
+    Returns:
+        str: The text with any logon code replaced
+    """
+    return _LOGON_PATTERN.sub(r"\1<redacted>", str(text))
 
 
 class ConnectionManager:
     """Manages network connections to the CPDLC service.
 
-    Every call into hoppie_connector goes through _call(), which converts
-    transport failures into HoppieError. hoppie_connector raises the builtin
-    ConnectionError for any non-OK HTTP status, and requests raises its own
-    OSError subclasses for timeouts and DNS failures. Neither is a
-    HoppieError, so without this they escape the `except HoppieError` in every
-    caller and disappear into the wx event loop, leaving a request silently
-    doing nothing at all.
+    Every call into hoppie_connector goes through _call(), which converts both
+    transport failures (TRANSPORT_ERRORS) and input/response failures
+    (PROTOCOL_ERRORS) into HoppieError. hoppie_connector raises the builtin
+    ConnectionError for a non-OK HTTP status, requests raises its own errors
+    for timeouts and DNS failures, and the message and response parsers raise
+    bare ValueError/TypeError. None of those is a HoppieError, so without this
+    they would escape the `except HoppieError` in every caller and disappear
+    into the wx event loop, leaving a request silently doing nothing at all.
+
+    Transport failures are also counted -- polls into connection_failures and
+    sends into send_failures -- so a link that is dead for sends but alive for
+    polls still reaches the reconnection logic instead of being reset by the
+    next successful poll.
     """
-
-    @staticmethod
-    def _call(operation):
-        """Run a hoppie_connector call, normalising transport failures.
-
-        Args:
-            operation: A zero-argument callable performing the request
-
-        Returns:
-            Whatever the operation returns
-
-        Raises:
-            HoppieError: For both protocol and transport failures
-        """
-        try:
-            return operation()
-        except HoppieError:
-            raise
-        except OSError as exc:
-            # Covers the builtin ConnectionError that hoppie_connector raises
-            # for a bad HTTP status, and requests' own error hierarchy.
-            raise HoppieError(str(exc)) from exc
 
     def __init__(self, logger, message_callback=None):
         """Initialize the connection manager.
@@ -56,12 +103,104 @@ class ConnectionManager:
         self.logon_code = ""
         self.network_type = None
         self.connection_failures = 0
-        self.max_connection_failures = 3
+        # Send failures are tracked separately: a successful poll must not
+        # clear them, or a link that passes GETs but blocks POSTs would never
+        # accumulate enough failures to trigger a reconnection.
+        self.send_failures = 0
+        self.max_connection_failures = MAX_CONNECTION_FAILURES
         self.message_callback = message_callback
+
+    def _call(self, operation, is_send=False):
+        """Run a hoppie_connector call, normalising its failure modes.
+
+        Args:
+            operation: A zero-argument callable performing the request
+            is_send: True for outbound message sends, which count towards
+                send_failures rather than connection_failures
+
+        Returns:
+            Whatever the operation returns
+
+        Raises:
+            HoppieError: For transport, protocol and validation failures
+        """
+        try:
+            result = operation()
+        except TRANSPORT_ERRORS as exc:
+            raise self._transport_failure(exc, is_send) from exc
+        except PROTOCOL_ERRORS as exc:
+            # Not a link problem: a too-long telex or a bad callsign fails here
+            # and must not push the client towards a reconnection.
+            error = HoppieError(redact(exc))
+            error.is_transport = False
+            raise error from exc
+
+        if is_send:
+            self.send_failures = 0
+        return result
+
+    def _transport_failure(self, exc, is_send=False):
+        """Count a transport failure and build the HoppieError for it.
+
+        Args:
+            exc: The original transport exception
+            is_send: True if the failure was on an outbound send
+
+        Returns:
+            HoppieError: The error to raise, tagged as a transport failure
+        """
+        if is_send:
+            self.send_failures += 1
+            count = self.send_failures
+            kind = "Send failure"
+        else:
+            self.connection_failures += 1
+            count = self.connection_failures
+            kind = "Connection failure"
+        self.logger.warning(f"{kind} count: {count}/{self.max_connection_failures}")
+        error = HoppieError(redact(exc))
+        error.is_transport = True
+        return error
+
+    def _api_url(self, network_type=None):
+        """Return the API URL for a network type.
+
+        Args:
+            network_type: Network type, or None to use the stored one
+
+        Returns:
+            str: The API URL to use
+        """
+        if network_type is None:
+            network_type = self.network_type
+        return HOPPIE_API_URL if network_type == "hoppie" else SAYINTENTIONS_API_URL
 
     def is_connected(self):
         """Check if currently connected to the network."""
         return self.cnx is not None
+
+    def _open(self, callsign, logon_code, network_type):
+        """Build a connector and verify it can reach the server.
+
+        HoppieConnector's constructor performs no I/O, so it alone proves
+        nothing. ping() is documented as a connection check, and it also
+        validates the callsign and logon code against the server.
+
+        Args:
+            callsign: Aircraft callsign
+            logon_code: CPDLC logon code
+            network_type: Network type ("sayintentions" or "hoppie")
+
+        Returns:
+            HoppieConnector: A verified connector
+
+        Raises:
+            HoppieError: If the connection could not be established
+        """
+        api_url = self._api_url(network_type)
+        cnx = self._call(lambda: HoppieConnector(callsign, logon_code, url=api_url))
+        self._call(cnx.ping)
+        return cnx
 
     def connect(self, callsign, logon_code, network_type="sayintentions"):
         """Connect to the CPDLC network.
@@ -78,16 +217,8 @@ class ConnectionManager:
             f"Attempting to connect as {callsign} to {network_type} network"
         )
 
-        # Select the appropriate API URL based on network type
-        if network_type == "hoppie":
-            api_url = HOPPIE_API_URL
-        else:  # Default to SayIntentions
-            api_url = SAYINTENTIONS_API_URL
-
         try:
-            self.cnx = self._call(
-                lambda: HoppieConnector(callsign, logon_code, url=api_url)
-            )
+            self.cnx = self._open(callsign, logon_code, network_type)
         except HoppieError:
             self.cnx = None
             raise
@@ -96,6 +227,7 @@ class ConnectionManager:
         self.logon_code = logon_code
         self.network_type = network_type
         self.connection_failures = 0
+        self.send_failures = 0
         self.logger.info(
             f"Successfully connected as {callsign} to {network_type} network"
         )
@@ -106,14 +238,23 @@ class ConnectionManager:
             return
 
         self.logger.info("Disconnecting from CPDLC network")
+        # Mirror connect(): clear every field it set, so a later reconnection
+        # cannot resurrect the previous session's callsign or logon code.
         self.cnx = None
+        self.callsign = ""
+        self.logon_code = ""
+        self.network_type = None
+        self.connection_failures = 0
+        self.send_failures = 0
         self.logger.info("Successfully disconnected")
 
     def poll(self):
         """Poll for new messages from the network.
 
         Returns:
-            tuple: (messages, poll_status) or (None, None) if not connected
+            tuple: (messages, poll_status) on success, where messages may be an
+                empty list. (None, None) if not connected or if the poll
+                failed; poll_failed() distinguishes the two.
         """
         if not self.cnx:
             return None, None
@@ -130,21 +271,33 @@ class ConnectionManager:
             self.connection_failures = 0
 
             return messages, poll_status
-        except HoppieError as exc:
-            self.logger.error(f"Poll error: {exc}")
-
-            # Increment connection failures counter
-            self.connection_failures += 1
-            self.logger.warning(
-                f"Connection failure count: {self.connection_failures}/{self.max_connection_failures}"
-            )
-
+        except Exception as exc:
+            # Deliberately broad: anything that escapes here would otherwise
+            # skip the counter entirely and disable reconnection for good.
+            self.logger.error(f"Poll error: {redact(exc)}")
+            if not getattr(exc, "is_transport", False):
+                # _call already counted transport failures. A poll carries no
+                # user input, so any other failure — an unparseable body from a
+                # captive portal, a server-side error — is equally a dead link.
+                self.connection_failures += 1
+                self.logger.warning(
+                    f"Connection failure count: {self.connection_failures}/{self.max_connection_failures}"
+                )
             return None, None
+
+    def failure_count(self):
+        """Return the worst of the poll and send failure counts."""
+        return max(self.connection_failures, self.send_failures)
+
+    def poll_failed(self):
+        """Check whether the connection is currently in a failed state."""
+        return self.failure_count() > 0
 
     def should_attempt_reconnection(self):
         """Check if reconnection should be attempted based on failure count."""
-        return (
-            self.connection_failures >= self.max_connection_failures
+        return bool(
+            self.cnx
+            and self.failure_count() >= self.max_connection_failures
             and self.callsign
             and self.logon_code
         )
@@ -161,21 +314,11 @@ class ConnectionManager:
 
         try:
             self.logger.info(f"Attempting to reconnect as {self.callsign}...")
-
-            # Select the appropriate API URL based on stored network type
-            if self.network_type == "hoppie":
-                api_url = HOPPIE_API_URL
-            else:
-                api_url = SAYINTENTIONS_API_URL
-
-            self.cnx = HoppieConnector(
-                self.callsign,
-                self.logon_code,
-                url=api_url,
-            )
+            self.cnx = self._open(self.callsign, self.logon_code, self.network_type)
 
             # Reset connection failures counter
             self.connection_failures = 0
+            self.send_failures = 0
             self.logger.info(f"Reconnection successful for {self.callsign}")
             return True
         except HoppieError as exc:
@@ -202,7 +345,8 @@ class ConnectionManager:
         self._call(
             lambda: self.cnx.send_cpdlc(
                 recipient, min_value, response_type, message, mrn=mrn
-            )
+            ),
+            is_send=True,
         )
 
     def send_telex(self, recipient, message):
@@ -218,10 +362,71 @@ class ConnectionManager:
         if not self.cnx:
             raise HoppieError("Not connected")
 
-        self._call(lambda: self.cnx.send_telex(recipient, message))
+        self._call(lambda: self.cnx.send_telex(recipient, message), is_send=True)
+
+    def _send_info_request(self, icao, packet, label):
+        """Send an inforeq request via a direct HTTP GET.
+
+        hoppie_connector does not support the inforeq message type, so this
+        builds the request itself but routes the failure handling through
+        _call() so the error contract matches every other outbound call.
+
+        Args:
+            icao: Airport ICAO code
+            packet: Packet content (e.g. "metar EDDF")
+            label: Human-readable request name for logs and errors
+
+        Returns:
+            str: The response text
+
+        Raises:
+            HoppieError: If not connected or the request fails
+        """
+        if not self.cnx:
+            raise HoppieError("Not connected")
+
+        api_url = self._api_url()
+        params = {
+            "logon": self.logon_code,
+            "from": self.callsign,
+            "to": "SERVER",
+            "type": "inforeq",
+            "packet": packet,
+        }
+
+        self.logger.info(f"Requesting {label} for {icao}")
+
+        def _fetch():
+            response = requests.get(api_url, params=params, timeout=NETWORK_TIMEOUT)
+            response.raise_for_status()
+            return response
+
+        try:
+            response = self._call(_fetch)
+        except HoppieError as exc:
+            self.logger.error(f"{label} request failed: {exc}")
+            raise HoppieError(f"{label} request failed: {exc}") from exc
+
+        body = response.text.strip()
+
+        if body.startswith("ok "):
+            text = body[3:].strip()
+            # Response is wrapped as {server info {actual text}} — extract inner content
+            match = _SERVER_INFO_PATTERN.match(text)
+            if match:
+                text = match.group(1).strip()
+            self.logger.info(f"Received {label} for {icao}")
+            return text
+        elif body.startswith("error "):
+            error_reason = body[6:].strip()
+            self.logger.error(f"{label} request error: {error_reason}")
+            raise HoppieError(f"{label} request error: {error_reason}")
+        else:
+            self.logger.error(f"Unexpected {label} response: {body}")
+            raise HoppieError(f"Unexpected response: {body}")
 
     def send_metar_request(self, icao):
-        """Send a METAR information request via the Hoppie API.
+        """Send a METAR information request.
 
         Args:
             icao: Airport ICAO code
@@ -232,56 +437,14 @@ class ConnectionManager:
         Raises:
             HoppieError: If not connected or request fails
         """
-        if not self.cnx:
-            raise HoppieError("Not connected")
-
-        # Select the appropriate API URL based on stored network type
-        if self.network_type == "hoppie":
-            api_url = HOPPIE_API_URL
-        else:
-            api_url = SAYINTENTIONS_API_URL
-
-        params = {
-            "logon": self.logon_code,
-            "from": self.callsign,
-            "to": "SERVER",
-            "type": "inforeq",
-            "packet": f"metar {icao}",
-        }
-
-        self.logger.info(f"Requesting METAR for {icao}")
-
-        try:
-            response = requests.get(api_url, params=params, timeout=15)
-            response.raise_for_status()
-        except requests.RequestException as exc:
-            self.logger.error(f"METAR request failed: {exc}")
-            raise HoppieError(f"METAR request failed: {exc}")
-
-        body = response.text.strip()
-
-        if body.startswith("ok "):
-            metar_text = body[3:].strip()
-            import re
-            match = re.match(r"^\{server info \{(.+)\}\}$", metar_text, re.DOTALL)
-            if match:
-                metar_text = match.group(1).strip()
-            self.logger.info(f"Received METAR for {icao}")
-            return metar_text
-        elif body.startswith("error "):
-            error_reason = body[6:].strip()
-            self.logger.error(f"METAR request error: {error_reason}")
-            raise HoppieError(f"METAR request error: {error_reason}")
-        else:
-            self.logger.error(f"Unexpected METAR response: {body}")
-            raise HoppieError(f"Unexpected response: {body}")
+        return self._send_info_request(icao, f"metar {icao}", "METAR")
 
     def send_atis_request(self, icao):
-        """Send an ATIS information request via the Hoppie API.
+        """Send an ATIS information request.
 
-        Makes a direct HTTP GET request since hoppie_connector doesn't
-        support the inforeq message type. Always uses Hoppie's API since
-        vatatis is a Hoppie-specific feature.
+        Note:
+            vatatis is a Hoppie-specific feature, so this request is only
+            meaningful when connected to the Hoppie network.
 
         Args:
             icao: Airport ICAO code
@@ -292,47 +455,4 @@ class ConnectionManager:
         Raises:
             HoppieError: If not connected or request fails
         """
-        if not self.cnx:
-            raise HoppieError("Not connected")
-
-        # Select the appropriate API URL based on stored network type
-        if self.network_type == "hoppie":
-            api_url = HOPPIE_API_URL
-        else:
-            api_url = SAYINTENTIONS_API_URL
-
-        params = {
-            "logon": self.logon_code,
-            "from": self.callsign,
-            "to": "SERVER",
-            "type": "inforeq",
-            "packet": f"vatatis {icao}",
-        }
-
-        self.logger.info(f"Requesting ATIS for {icao}")
-
-        try:
-            response = requests.get(api_url, params=params, timeout=15)
-            response.raise_for_status()
-        except requests.RequestException as exc:
-            self.logger.error(f"ATIS request failed: {exc}")
-            raise HoppieError(f"ATIS request failed: {exc}")
-
-        body = response.text.strip()
-
-        if body.startswith("ok "):
-            atis_text = body[3:].strip()
-            # Response is wrapped as {server info {actual text}} — extract inner content
-            import re
-            match = re.match(r"^\{server info \{(.+)\}\}$", atis_text, re.DOTALL)
-            if match:
-                atis_text = match.group(1).strip()
-            self.logger.info(f"Received ATIS for {icao}")
-            return atis_text
-        elif body.startswith("error "):
-            error_reason = body[6:].strip()
-            self.logger.error(f"ATIS request error: {error_reason}")
-            raise HoppieError(f"ATIS request error: {error_reason}")
-        else:
-            self.logger.error(f"Unexpected ATIS response: {body}")
-            raise HoppieError(f"Unexpected response: {body}")
+        return self._send_info_request(icao, f"vatatis {icao}", "ATIS")

--- a/src/model/connection_manager.py
+++ b/src/model/connection_manager.py
@@ -10,7 +10,38 @@ from src.config import SAYINTENTIONS_API_URL, HOPPIE_API_URL
 
 
 class ConnectionManager:
-    """Manages network connections to the CPDLC service."""
+    """Manages network connections to the CPDLC service.
+
+    Every call into hoppie_connector goes through _call(), which converts
+    transport failures into HoppieError. hoppie_connector raises the builtin
+    ConnectionError for any non-OK HTTP status, and requests raises its own
+    OSError subclasses for timeouts and DNS failures. Neither is a
+    HoppieError, so without this they escape the `except HoppieError` in every
+    caller and disappear into the wx event loop, leaving a request silently
+    doing nothing at all.
+    """
+
+    @staticmethod
+    def _call(operation):
+        """Run a hoppie_connector call, normalising transport failures.
+
+        Args:
+            operation: A zero-argument callable performing the request
+
+        Returns:
+            Whatever the operation returns
+
+        Raises:
+            HoppieError: For both protocol and transport failures
+        """
+        try:
+            return operation()
+        except HoppieError:
+            raise
+        except OSError as exc:
+            # Covers the builtin ConnectionError that hoppie_connector raises
+            # for a bad HTTP status, and requests' own error hierarchy.
+            raise HoppieError(str(exc)) from exc
 
     def __init__(self, logger, message_callback=None):
         """Initialize the connection manager.
@@ -54,10 +85,8 @@ class ConnectionManager:
             api_url = SAYINTENTIONS_API_URL
 
         try:
-            self.cnx = HoppieConnector(
-                callsign,
-                logon_code,
-                url=api_url,
+            self.cnx = self._call(
+                lambda: HoppieConnector(callsign, logon_code, url=api_url)
             )
         except HoppieError:
             self.cnx = None
@@ -91,7 +120,7 @@ class ConnectionManager:
 
         try:
             self.logger.debug("Polling for new messages")
-            messages, poll_status = self.cnx.poll()
+            messages, poll_status = self._call(self.cnx.poll)
 
             # Reset connection failures counter on successful poll
             if self.connection_failures > 0:
@@ -170,7 +199,11 @@ class ConnectionManager:
         if not self.cnx:
             raise HoppieError("Not connected")
 
-        self.cnx.send_cpdlc(recipient, min_value, response_type, message, mrn=mrn)
+        self._call(
+            lambda: self.cnx.send_cpdlc(
+                recipient, min_value, response_type, message, mrn=mrn
+            )
+        )
 
     def send_telex(self, recipient, message):
         """Send a TELEX message.
@@ -185,7 +218,7 @@ class ConnectionManager:
         if not self.cnx:
             raise HoppieError("Not connected")
 
-        self.cnx.send_telex(recipient, message)
+        self._call(lambda: self.cnx.send_telex(recipient, message))
 
     def send_metar_request(self, icao):
         """Send a METAR information request via the Hoppie API.

--- a/src/model/cpdlc_session.py
+++ b/src/model/cpdlc_session.py
@@ -237,6 +237,29 @@ class CpdlcSession:
         self.cpdlc_min_counter += 1
         return True, response
 
+    def _request_info(self, icao: str, label: str, send) -> Tuple[bool, Optional[str]]:
+        """Run an information request and normalise the result.
+
+        Args:
+            icao: Airport ICAO code
+            label: Human-readable request name for log messages
+            send: Callable taking the ICAO code and returning the response text
+
+        Returns:
+            tuple: (success, text_or_error)
+        """
+        if not self.connection_manager.is_connected():
+            self.logger.warning(
+                f"{label} request attempted without active connection"
+            )
+            return False, None
+
+        try:
+            return True, send(icao)
+        except HoppieError as exc:
+            self.logger.error(f"Failed to request {label} for {icao}: {exc}")
+            return False, str(exc)
+
     def request_atis(self, icao: str) -> Tuple[bool, Optional[str]]:
         """Request ATIS information for an airport.
 
@@ -246,16 +269,9 @@ class CpdlcSession:
         Returns:
             tuple: (success, atis_text_or_error)
         """
-        if not self.connection_manager.is_connected():
-            self.logger.warning("ATIS request attempted without active connection")
-            return False, None
-
-        try:
-            atis_text = self.connection_manager.send_atis_request(icao)
-            return True, atis_text
-        except HoppieError as exc:
-            self.logger.error(f"Failed to request ATIS for {icao}: {exc}")
-            return False, str(exc)
+        return self._request_info(
+            icao, "ATIS", self.connection_manager.send_atis_request
+        )
 
     def send_direct_request(
         self, fix: str, reason: Optional[str] = None
@@ -372,16 +388,9 @@ class CpdlcSession:
         Returns:
             tuple: (success, metar_text_or_error)
         """
-        if not self.connection_manager.is_connected():
-            self.logger.warning("METAR request attempted without active connection")
-            return False, None
-
-        try:
-            metar_text = self.connection_manager.send_metar_request(icao)
-            return True, metar_text
-        except HoppieError as exc:
-            self.logger.error(f"Failed to request METAR for {icao}: {exc}")
-            return False, str(exc)
+        return self._request_info(
+            icao, "METAR", self.connection_manager.send_metar_request
+        )
 
     def send_telex(self, recipient: str, message: str) -> Tuple[bool, Optional[str]]:
         """Send a TELEX message.


### PR DESCRIPTION
When the ACARS server returns an HTTP error, sending a request does nothing at all — no message in the list, no error dialog, and nothing in the log. The user is left pressing send repeatedly with no feedback.

Found while a SayIntentions server was returning 502 Bad Gateway. From a real log:

```
15:56:46  INFO   Requesting FL390 due to AIRCRAFT PERFORMANCE
15:56:51  ERROR  Unexpected error during poll: Error 502: Bad Gateway
15:57:06  INFO   Requesting FL390 due to AIRCRAFT PERFORMANCE
15:57:30  INFO   Requesting FL390
15:57:38  ERROR  Unexpected error during poll: Error 502: Bad Gateway
```

Three altitude change requests, and no "Failed to send altitude change request" after any of them. The `Requesting FL390` line is written *before* the send is attempted, so all three vanished between there and the network.

## Cause

`hoppie_connector` raises the **builtin** `ConnectionError` for any non-OK HTTP status ([API.py](https://github.com/islandcontroller/hoppie-connector/blob/master/src/hoppie_connector/API.py)):

```python
if not response.ok:
    raise ConnectionError(f"Error {response.status_code}: {response.reason}")
```

`ConnectionError` is not a `HoppieError`, so it slips straight past the `except HoppieError` that every send path relies on:

```python
try:
    self.connection_manager.send_cpdlc(...)
except HoppieError as exc:
    self.logger.error(f"Failed to send altitude change request: {exc}")
    return False, str(exc)
```

It then propagates out of `send_altitude_change_request`, out of `on_altitude_change`, and is swallowed by the wx event loop. Reproduced directly:

```
EXCEPTION ESCAPED: ConnectionError: Error 502: Bad Gateway
```

This affects every outbound message — logon, logoff, altitude, direct, speed, when-can-we, telex, PDC and acknowledgements — for any 5xx or 4xx, and equally for a `requests` timeout or DNS failure, since those are also not `HoppieError`.

## Fix

Every call into `hoppie_connector` now goes through `ConnectionManager._call()`, which converts transport failures into `HoppieError` at the boundary:

```python
try:
    return operation()
except HoppieError:
    raise
except OSError as exc:
    # Covers the builtin ConnectionError that hoppie_connector raises for a
    # bad HTTP status, and requests' own error hierarchy.
    raise HoppieError(str(exc)) from exc
```

`OSError` covers both cases: the builtin `ConnectionError` subclasses it, and so does `requests.RequestException` via `IOError`. Programming errors are deliberately not caught.

All existing error handling then works unchanged, and the user gets the error dialog the code always intended to show.

One file, +41/-8.

## Verification

With a stub connector raising `ConnectionError("Error 502: Bad Gateway")`:

```
altitude request -> success=False, error='Error 502: Bad Gateway'
telex            -> success=False, error='Error 502: Bad Gateway'
logon            -> success=False, error='Error 502: Bad Gateway'
poll             -> None, failures counted: 1
```

Before the change the first three raised instead of returning, which is what made them silent.

## Side benefit

A bad HTTP status during a poll previously escaped `ConnectionManager.poll()` entirely and was caught by the polling controller's generic handler, so it never incremented `connection_failures`. It now counts, meaning repeated failures trigger the existing reconnection logic rather than the client sitting there indefinitely against a failing server.

## Note on overlap

Independent of #24 and #25, and touches a file neither of them changes, so all three can merge in any order.
