### PR TITLE
Run the test suite in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    # Windows to match build-and-release.yml: this is a Windows app and the
+    # GUI tests construct real wx windows.
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
The pytest suite added alongside the PR #25 review follow-ups only guards regressions if it actually runs. `build-and-release.yml` is triggered by a release, so it cannot catch a bad push or PR.

Adds a `Tests` workflow on push to `main` and on every PR:

- `windows-latest` and Python 3.13, matching `build-and-release.yml` — this is a Windows app, and the GUI tests construct real `wx` windows.
- Installs `requirements-dev.txt`, so CI exercises the same pinned dependency set the app declares.
- pip caching keyed on both requirements files.

This PR is itself the first run of the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)