### PR TITLE
Test harness hermeticity and protocol regression tests (audit package 1)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ jobs:
     # Windows to match build-and-release.yml: this is a Windows app and the
     # GUI tests construct real wx windows.
     runs-on: windows-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code

--- a/docs/audit/2026-09-03-codebase-audit.md
+++ b/docs/audit/2026-09-03-codebase-audit.md
@@ -1,0 +1,348 @@
+# Sim-CPDLC codebase audit — 2026-09-03
+
+**Commit audited:** `9c06458` (main, clean tree).
+**Baseline:** full test suite passes (135 tests, 1.2 s) using the wxPython venv under `.claude/worktrees/review-25-ceb148/.venv`.
+
+## Scope and method
+
+- Read in full: `app.py`, everything under `src/` (about 5,700 lines), everything under `tests/` (about 1,900 lines), README, TODOS, the PR-24 spec, `app.spec`, `sim-cpdlc.iss`, `version_info.txt`, `update_version.py`, requirements, CI workflows.
+- Read in full: the source of `hoppie_connector` 0.2.1, the library every network call goes through. Several findings depend on its behaviour (ASCII-only decoding, a strict character whitelist for CPDLC text, per-message parse failures downgraded to Python warnings).
+- Four independent review passes were run with separate lenses (threading and wx lifecycle, network and protocol, GUI/state/configuration/packaging, test suite). Their raw reports are listed in the appendix. Every finding below was cross-checked against the current code; findings marked **verified by execution** were reproduced with the real library in the loop, using in-process fakes for `requests.get`/`requests.post` (no network traffic, repo untouched).
+- Items in `TODOS.md` and the PR-24 spec were re-checked; all are fixed as recorded, including the spec's "out of scope" list. The accepted WON'T FIX (unbounded message log) is not reported.
+
+**Severity scale**
+
+| Level | Meaning here |
+|---|---|
+| High | Silent loss of ATC communication, or the app becomes unusable for a screen-reader user under realistic conditions |
+| Medium | Wrong behaviour a pilot would notice in normal use, wrong state that persists, or a latent fault that corrupts the developer's environment |
+| Low | Edge cases, misleading feedback, robustness gaps, documentation and packaging drift |
+| Info | Code quality with no user-visible effect |
+
+**Confidence:** *Confirmed* = traced in code (and usually reproduced); *Plausible* = mechanism confirmed but the trigger frequency or a platform detail could not be measured.
+
+---
+
+## Summary
+
+| ID | Sev | Area | Finding |
+|---|---|---|---|
+| H-1 | High | Network/protocol | Uplinks the library cannot parse are dropped with no trace, after the server marked them delivered |
+| H-2 | High | Network/GUI | Polling stops for good after one failed automatic reconnection; only the status bar changes and the menu still says "Disconnect" |
+| H-3 | High | Threading/UX | Every CPDLC network call, the SimBrief fetch and the manual update check block the GUI thread (15–60 s worst case) |
+| M-1 | Medium | State | CPDLC session state is never reset on disconnect, failed reconnection or failed LOGOFF |
+| M-2 | Medium | Network | One non-ASCII byte in a poll response loses every message in that poll and counts as a link failure |
+| M-3 | Medium | Polling | An exception in the message callback discards the rest of the poll batch |
+| M-4 | Medium | Network/GUI | A non-`HoppieError` during automatic reconnection leaves the state machine stuck and stacks one error dialog per tick |
+| M-5 | Medium | Threading/UX | The update checker can pop over any modal dialog and closes the app on "Yes", from under an open dialog |
+| M-6 | Medium | Network/weather | An empty weather envelope `{server info {}}` is returned as report text; bare `ok` is reported as an unexpected response |
+| M-7 | Medium | Protocol | Manual logon while already logged on sends no LOGOFF and restarts the MIN counter mid-dialogue |
+| M-8 | Medium | GUI | Dialogs validate stripped text but return it unstripped |
+| M-9 | Medium | SimConnect | A failed `send_event` is reported as success; two SimConnect connection attempts per CONTACT on the GUI thread |
+| M-10 | Medium | Release | Source checkouts identify as 0.1.0: every launch offers an "update", About and bug reports carry a useless version |
+| M-11 | Medium | Tests | Fixtures are not hermetic: the real `config.json`, SimBrief and SimConnect are one call away |
+| M-12 | Medium | Tests | The acknowledgement RR/MIN, the MRN check and half the response table have no regression tests |
+| L-1 | Low | Polling | "Connection problem (n/3) - retrying..." shown after one failed *send*, until the next successful send |
+| L-2 | Low | Protocol | A TELEX reading `LOGON ACCEPTED` / `LOGOFF` / `HANDOVER XXXX` drives CPDLC session state |
+| L-3 | Low | Protocol | Logon lifecycle has no negative paths (exact match only, no rejection handling, pending state never expires) |
+| L-4 | Low | Threading | Weather cycle has no deadline; an in-flight cycle survives reconnect and may mix credentials |
+| L-5 | Low | Threading | Worker-thread `IsBeingDeleted()` guards do not work and can raise at exit |
+| L-6 | Low | Logging | SimBrief diagnostics never reach the log file; the console handler is dead in the windowed build |
+| L-7 | Low | GUI | Input validation gaps in the request dialogs |
+| L-8 | Low | Security | Unredacted logon code survives in the exception chain; DEBUG logging prints both logon codes |
+| L-9 | Low | GUI | `on_disconnect` sleeps 500 ms on the GUI thread for nothing and re-arms polling before stopping it |
+| L-10 | Low | GUI | Settings applies the weather interval before the save succeeds |
+| L-11 | Low | GUI | `resource_path` resolves against the current directory in development mode |
+| L-12 | Low | Display | `@@` becomes `N/A` glued to neighbouring words; list columns never resized |
+| L-13 | Low | GUI | `dlg.Destroy()` is skipped when anything raises between `ShowModal()` and the end of the handler |
+| L-14 | Low | Lifecycle | Exception reporter opens a modal inside the failing handler; `OnExceptionInMainLoop` and the Ctrl+C branch are dead or wrong |
+| L-15 | Low | Lifecycle | `_confirm_exit` ignores `CanVeto()`; first-launch prompt runs mid-`__init__` |
+| L-16 | Low | GUI | Weather subscriptions dialog gives no confirmation on stop and can list stale entries |
+| L-17 | Low | Protocol/parsing | Inforeq error text keeps braces; HANDOVER regex demands the exact form; frequency parser needs a unit name; every non-ack uplink extends active polling |
+| L-18 | Low | Docs | README drift: Python 3.7 (3.12 required), climb/descent option, sound policy, "Automatic Reconnection", tests table |
+| L-19 | Low | Packaging | pyinstaller in runtime requirements; SimConnect unpinned and its DLL optional; `.gitignore` gaps; release does not run tests |
+| L-20 | Low | Hygiene | Personal SimBrief data and a live-API script committed under `src/` |
+| L-21 | Low | Tests | Vacuous or weak tests; large untested areas; small fixture leaks |
+| I-1..I-5 | Info | Quality | Unused imports, dead code, duplication, aliases, uneven accessibility conventions, misc |
+
+---
+
+## High
+
+### H-1. Uplinks the library cannot parse are dropped with no trace, after the server has marked them delivered
+
+- **Area:** Network/protocol. **Confidence:** Confirmed (mechanism, verified by execution); frequency on the live networks is Plausible.
+- **Where:** `hoppie_connector/__init__.py:77-85` (`poll()`), `hoppie_connector/Messages.py:602,613,639-641` (`CpdlcMessage` whitelist `[A-Z0-9._@ ]`), `src/model/connection_manager.py:284-308`, `src/controller/polling_controller.py:149-176`, `app.spec:59` (`console=False`).
+- **What is wrong:** `HoppieConnector.poll()` parses each item of the poll body and, on any `ValueError`, calls `warnings.warn(..., HoppieWarning)` and drops the item. The app never captures warnings (no `warnings.catch_warnings`, no `logging.captureWarnings`), and in the packaged build `sys.stderr` is `None`, so the warning goes nowhere. `ConnectionManager.poll()` sees a clean result, no counter moves, nothing is logged, nothing reaches the list. Hoppie marks messages as relayed when it serves them, so the message is gone for good.
+- **What the library refuses (verified by execution):** CPDLC text containing any of `/ , : - ( )`, lowercase letters or a newline; telex longer than 220 characters or containing any non-ASCII character; unknown message types. A poll body with three items (`CLIMB TO FL350`, `QNH 1013 / TRL 70`, a 221-character telex) delivered one message and emitted two warnings; the app logged nothing.
+- **Failure scenario:** Controller sends `CONTACT LANGEN 127.825 (SECONDARY 121.500)` or a free-text uplink with a slash or comma. The controller's client shows "delivered", waits for WILCO, escalates by voice or assumes non-compliance; the pilot never saw it.
+- **Fix direction:** Wrap `self.cnx.poll` in `warnings.catch_warnings(record=True)` (filter `HoppieWarning`), log each dropped item at ERROR with sender and raw packet, and add a SYSTEM row with the notification sound ("Unreadable message from EDGG: …") so the pilot can ask by voice. Longer term, parse `cpdlc` items with a permissive fallback (the raw `{FROM cpdlc {packet}}` is available). Measuring how often this happens is easy: compare Hoppie's web message log for a flight with `sim-cpdlc.log`.
+
+### H-2. Polling stops for good after one failed automatic reconnection, with no notification beyond the status bar; the menu still says "Disconnect"
+
+- **Area:** Network/GUI. **Confidence:** Confirmed.
+- **Where:** `src/controller/polling_controller.py:181-196` (reconnection branch, `stop()`), `:205-217` (`_report_connection_state`, status bar only), `src/model/connection_manager.py:327-350` (`attempt_reconnection` clears `cnx` on failure), `src/gui/main_window.py:341-342, 397-398` (the only places the Connect/Disconnect label changes).
+- **What is wrong:** After `MAX_CONNECTION_FAILURES` (3) the controller calls `attempt_reconnection()` once, in the same tick, with no back-off. On failure `cnx` is cleared, the timer is stopped and nothing ever restarts it. Unlike connect and disconnect, this path adds no SYSTEM row and plays no sound; `_set_status` is the only output, which a screen-reader user must query by hand. `MainWindow` is never told: `menu_item_connect` keeps the label "&Disconnect" while `is_connected()` is false, so activating "Disconnect" opens the Connect dialog. `_reported_failure` is also never reset by `start()`, so the first good poll of the next session overwrites "Connected as X." with "Connection restored.". The weather monitor keeps ticking (and skipping) with its subscriptions intact. README promises "Automatic Reconnection: Handles connection issues gracefully".
+- **Failure scenario:** During an active exchange (20 s polls) the router reboots for 70 s. Polls at 0, 20 and 40 s fail; the ping at 40 s fails; polling stops. The link is back at 70 s, the client never polls again; the controller's next uplink sits on the server; the pilot, who heard nothing, keeps waiting for a reply. In idle mode the same happens after a 2–4 minute outage.
+- **Fix direction:** Keep polling with exponential back-off (for example 20 s → 60 s → 120 s capped) instead of stopping; treat `attempt_reconnection` as re-verification, not as terminal; give the controller an `on_connection_lost`/`on_reconnected` callback so the window can add a SYSTEM message, play the sound, and flip the menu label; reset `_reported_failure` in `start()`.
+
+### H-3. Every CPDLC network call, the SimBrief fetch and the manual update check block the GUI thread
+
+- **Area:** Threading/UX. **Confidence:** Confirmed (paths and timeout semantics); durations derived from the constants.
+- **Where:** `src/config.py:147` (`NETWORK_TIMEOUT = 15`), `src/model/connection_manager.py:221-222, 286, 368-373, 388`, `src/controller/polling_controller.py:149, 186`, `src/gui/main_window.py:324, 380, 734, 986, 1017, 1085`, `src/gui/dialogs/connect_dialog.py:62`, `src/gui/dialogs/pdc_dialog.py:53`, `src/utils/simbrief.py:28-32` (10 s), `src/utils/update_checker.py:40, 97` (5 s).
+- **What is wrong:** Only the automatic weather cycle runs on a worker thread. Connect/ping, every poll, every send, the manual weather request, the handover logon inside the poll tick, the SimConnect setup inside the poll tick, the SimBrief fetch inside two dialog constructors and the manual update check all block the wx main loop. A scalar `timeout=15` is a connect timeout plus a per-read timeout, not a total budget, so one call can take about 30 s (more for a trickling response; DNS is not bounded at all). While blocked, no timers fire, no `CallAfter` results are delivered, and UIA/MSAA queries from NVDA time out, so the user hears nothing.
+
+  | Operation | Worst-case freeze |
+  |---|---|
+  | File > Connect with a SimBrief id set | ~20 s before the dialog appears, then ~30 s after OK |
+  | Each poll tick during an outage | ~30 s out of every 20–75 s, then another ~30 s for the reconnection ping |
+  | Poll tick that carries a HANDOVER | poll + synchronous logon, ~60 s |
+  | Manual weather request / Exit or Disconnect while logged on | ~30 s |
+  | Manual update check | ~10 s |
+
+- **Failure scenario:** A server that accepts TCP and then goes silent freezes the UI for most of a two-to-four-minute stretch, ending in H-2. Keystrokes typed during the freeze are replayed onto whatever dialog appears next.
+- **Fix direction:** Reuse the `WeatherMonitor` pattern (snapshot on the GUI thread, worker, `wx.CallAfter` back) for poll, send and connect, with a single outstanding request per kind and "Connecting…"/"Sending…" status text. If that is too large a change at once, first move the SimBrief fetch out of the dialog constructors, thread the manual weather request and the manual update check, and split the timeout into a short connect timeout and a total read budget.
+
+---
+
+## Medium
+
+### M-1. CPDLC session state is never reset on disconnect, failed reconnection or failed LOGOFF
+
+- **Area:** State. **Confidence:** Confirmed.
+- **Where:** `src/model/cpdlc_session.py:24-28` (fields), `:108-141` (`logoff` leaves `current_station` set on failure), no reset method in the class; `src/gui/main_window.py:349-402` (`on_disconnect`), `:316-347` (`on_connect` only sets the callsign); `src/controller/polling_controller.py:182-196`.
+- **What is wrong:** `ConnectionManager.disconnect()` clears its own fields, but `current_station`, `pending_logon_min/station` and `cpdlc_min_counter` survive a disconnect, a failed automatic reconnection and the next `connect()`, even under a different callsign or network. `on_disconnect` inspects the LOGOFF result only to decide whether to echo the text; a failed LOGOFF (the common case when the reason for disconnecting is a dead link) produces no dialog and no SYSTEM row.
+- **Failure scenario:** Logged on to LSAG; the link drops; automatic reconnection fails. The user reconnects as a different flight. Status says "Connected as X." but `is_logged_on()` is still true: the Requests menu sends `REQUEST FL350` to LSAG with the old MIN sequence, old LSAG uplinks are answerable again from the context menu, and the exit confirmation talks about LSAG. Offline, `Requests > Logoff` only reports a send failure and cannot clear the state.
+- **Note:** Hoppie logon state lives in the ATC client keyed by callsign, so keeping the station across a reconnect with the *same* callsign may be intended (see questions at the end).
+- **Fix direction:** Add `CpdlcSession.reset()` (station, pending logon, MIN counter) and call it from `on_disconnect` after the LOGOFF attempt regardless of outcome, from the failed-reconnection path, and from `on_connect` when the callsign or network changes; surface a failed LOGOFF as a SYSTEM message.
+
+### M-2. One non-ASCII byte in a poll response loses every message in that poll and counts as a link failure
+
+- **Area:** Network. **Confidence:** Confirmed (verified by execution); whether the networks ever relay non-ASCII bytes is Plausible.
+- **Where:** `hoppie_connector/API.py:50` (`response.content.decode('ascii')`), `src/model/connection_manager.py:136-143, 296-308`.
+- **What is wrong:** The library decodes the whole body as ASCII before any per-message parsing. One `°`, `–` or umlaut in any telex/ATIS/free text raises `UnicodeDecodeError` (a `ValueError`) for the entire response. `_call` converts it to a protocol `HoppieError`; `poll()` logs "Poll error: 'ascii' codec can't decode…" and increments `connection_failures`. Reproduced: a body with a valid CLIMB instruction and a telex containing `°` returned `(None, None)`, `connection_failures` 1; the CLIMB was gone. Three such polls trigger H-2.
+- **Fix direction:** The app cannot change the decode inside the library, but it can shadow `HoppieAPI.connect` on `HoppieConnector._api` to decode with `errors="replace"` before parsing, and it should at least distinguish this in the log/status from a transport outage.
+
+### M-3. An exception in the message callback discards the rest of the poll batch
+
+- **Area:** Polling. **Confidence:** Confirmed.
+- **Where:** `src/controller/polling_controller.py:159-176`.
+- **What is wrong:** `poll()` returns the whole batch, already marked relayed by the server. The loop re-raises on the first failing `message_callback(message)`, so messages 2..n are never logged, displayed or applied to `CpdlcSession`, and `should_increase_polling_rate` is skipped. The `finally` keeps polling alive, but the batch is lost. Today the concrete triggers are the deliberately unconverted local `OSError`s from the network layer raised during the nested handover logon, or a wx error in the view; the guard exists because callback failures are anticipated.
+- **Failure scenario:** Batch `[uplink A, HANDOVER EDGG]`; handling A raises; the user sees an "Unexpected Error" box for A; the HANDOVER is gone, the client still believes it is logged on to the old station.
+- **Fix direction:** Keep the per-message `try`, log and continue with the remaining messages (still applying `should_increase_polling_rate`), then re-raise or report the first error after the loop. Adding the message to the list before running state/SimConnect logic would at least keep the text visible.
+
+### M-4. A non-`HoppieError` during automatic reconnection leaves the state machine stuck and stacks one error dialog per tick
+
+- **Area:** Network/GUI. **Confidence:** Confirmed (verified by execution); the trigger is uncommon.
+- **Where:** `src/model/connection_manager.py:19-24` (`TRANSPORT_ERRORS` deliberately excludes `OSError`), `:327-350` (`attempt_reconnection` catches only `HoppieError`), `src/controller/polling_controller.py:182-198`, `app.py:31-51` (reporter shows a modal synchronously).
+- **What is wrong:** `poll()` catches everything, so each `OSError` poll (for example a CA bundle path that became invalid mid-session) increments `connection_failures`. `attempt_reconnection()` lets the same `OSError` from `ping` escape: `cnx` keeps the old connector, the counter is not reset, `should_attempt_reconnection()` stays true. Reproduced: after one attempt, `cnx` unchanged, failures 3, still due. The escaped exception reaches the reporter, which opens a modal `wx.MessageBox` inside the timer dispatch; the `finally` has already re-armed the one-shot, so the next tick fires inside that modal loop, fails the same way and opens a second dialog on top, every 20–75 s until the user disconnects.
+- **Fix direction:** In `attempt_reconnection` (and `connect`) catch `Exception`, log, set `cnx = None`, return False, keeping the classification decision but not letting it break the state machine. In the reporter, coalesce dialogs (log only if one is already open) and show via `wx.CallAfter` even on the main thread so the failing handler unwinds first.
+
+### M-5. The update checker can pop over any modal dialog and closes the application on "Yes", from under an open dialog
+
+- **Area:** Threading/UX. **Confidence:** Plausible (each wx step verified in source; the end-to-end sequence was not executed).
+- **Where:** `src/utils/update_checker.py:42-49, 127-158` (`wx.CallAfter(self.parent.Close)` at 150), `src/gui/main_window.py:98-101` (auto check in `__init__`), `:1155-1158` (first launch schedules `on_settings` via `CallAfter`), `:250-296`.
+- **What is wrong:** The "Update Available" box is shown via `wx.CallAfter`, which the main loop dispatches even while another dialog's modal loop is running, so it appears parentless on top of whatever is open and steals focus. On Yes, `Close()` is dispatched inside the open dialog's modal loop: the frame's deferred destruction deletes the modal child, `ShowModal()` returns on a deleted object, and the handler continues with `dlg.Destroy()`/`dlg.get_settings()` on a dead proxy (`RuntimeError`). The prompt also does not say that Yes closes the program; when not connected the app closes with no further question.
+- **Failure scenario:** First launch → "set up now?" Yes → Settings opens → about a second later "Update Available" appears over the form → Yes → browser opens, the frame closes under Settings → "Unexpected Error: wrapped C/C++ object … has been deleted" → exit.
+- **Fix direction:** Do not close the application from the checker (open the browser and leave the user in control), or have the main window own the "update available" state and act on it only when no modal is active; give the prompt a parent; say in the text what Yes does.
+
+### M-6. An empty weather envelope is returned as report text; a bare `ok` is reported as an unexpected response
+
+- **Area:** Network/weather. **Confidence:** Confirmed (verified by execution); the exact empty-envelope form the servers use is Plausible (it is what the code's own comment assumes).
+- **Where:** `src/model/connection_manager.py:32` (`_SERVER_INFO_PATTERN` uses `(.+)`), `:433-449`, `:470-475`.
+- **What is wrong:** `(.+)` needs at least one character, so `ok {server info {}}` does not match, the unwrapping is skipped and the literal string `{server info {}}` is returned as the report; the `if not report_text` guard that the comment describes never fires. Bare `ok` falls to "Unexpected response: ok", which reads like a fault. `error {no data}` is reported with the braces kept.
+- **Failure scenario:** A subscription to a mistyped ICAO gets a list row "ATIS ZZZZ: {server info {}}" (announced with the sound as an "initial report"), and the subscription lives forever because every cycle returns the same text; a real report later flips it back and forth.
+- **Fix direction:** Use `(.*)`; treat `body == "ok"` and an empty inner text as "no report available" (a `HoppieError` the weather monitor already counts as a failure); strip the braces from the error reason.
+
+### M-7. Manual logon while already logged on sends no LOGOFF and restarts the MIN counter mid-dialogue
+
+- **Area:** Protocol. **Confidence:** Confirmed by reading.
+- **Where:** `src/model/cpdlc_session.py:62-106` (`cpdlc_min_counter = 1` at line 85; `current_station` untouched), `src/gui/main_window.py:404-449` (`on_logon` checks only `is_connected()`).
+- **What is wrong:** `logon()` is callable in any state. It resets MIN to 1 and records a pending logon but keeps `current_station`. Until the new station accepts, every request goes to the *old* station numbered 2, 3, … which that station already saw earlier; if the new station accepts, the old one is never told. Re-logging on to the same station (a natural thing to try when the pilot suspects they were dropped, since the app gives no indication either way) restarts MIN on a dialogue the station may consider open. `pending_logon_*` is never cleared by `logoff()`, `handle_station_logoff()` or disconnect.
+- **Fix direction:** In `on_logon`, if logged on, either refuse ("log off first") or send LOGOFF and clear the station before the new REQUEST LOGON; restart MIN only when the previous dialogue was actually closed; clear pending state on logoff/disconnect.
+
+### M-8. Dialogs validate stripped text but return it unstripped
+
+- **Area:** GUI. **Confidence:** Confirmed (library rejects `"EDDF "` with "Invalid TO station name").
+- **Where:** `src/gui/dialogs/logon_dialog.py:48` vs `:60`, `connect_dialog.py:173` vs `:197`, `pdc_dialog.py:141-146` vs `:165-171`, `telex_dialog.py:56-58` vs `:71-73`, `settings_dialog.py:179-186`; consumer `src/gui/main_window.py:421-428`.
+- **What is wrong:** Every `on_text_change` strips before checking, but the getters return `GetValue().upper()` (or raw) without stripping. `hoppie_connector` validates station names as `^[A-Z0-9]{3,8}$`, so an invisible leading or trailing space passes the OK gate and fails at send time. Logon is the worst case: "EDDF " enables OK, then `on_logon` measures the unstripped value and shows "Station name must be exactly 4 characters long." Settings saves logon codes with surrounding whitespace, after which every connection fails with the server's invalid-logon error.
+- **Fix direction:** Strip in every getter (and in `SettingsDialog.get_settings`), after which the length re-check in `on_logon` becomes redundant.
+
+### M-9. SimConnect auto-tune: a failed `send_event` is reported as success; two connection attempts per CONTACT on the GUI thread
+
+- **Area:** SimConnect. **Confidence:** Confirmed for the ignored return value and the retry logic (upstream Python-SimConnect source); Plausible for the unbounded wait.
+- **Where:** `src/utils/simconnect_manager.py:37-60` (`connect`), `:74-111` (`set_com1_standby_mhz`; return value of `send_event` ignored at 96–100; `_sm` dropped without `exit()` at 101–109), `src/gui/main_window.py:1009-1027` (called from the poll tick; `load_config()` from disk on every message).
+- **What is wrong:** Upstream `send_event()` returns `False` on failure rather than raising; the manager logs "COM1 standby set" and returns True regardless, so after MSFS is closed and reopened every CONTACT "succeeds" without tuning anything and the "Auto-tune failed" status never appears. When the simulator is not running, each CONTACT/MONITOR runs two full connection attempts on the GUI thread (the availability cache is reset between them). Upstream `connect()` also busy-waits without a timeout for the OPEN reply after a successful pipe open, which would spin the GUI thread inside a poll tick if the simulator delays it. On the retry path the previous `SimConnect` object is dropped without `exit()`, potentially orphaning its dispatch thread. `auto_tune_com1` defaults to True, so users without MSFS pay this on every CONTACT.
+- **Fix direction:** Check the return of `send_event()`; treat a `None` event id as a failed connect; call `exit()` before dropping the object; connect once (at network connect time, off the GUI thread, with a watchdog) and only `send_event` from the message path; cache `auto_tune_com1` instead of re-reading the config file per message.
+
+### M-10. Source checkouts identify as 0.1.0: every launch offers an "update", About and bug reports carry a useless version
+
+- **Area:** Release. **Confidence:** Confirmed (`git show v2.1.2:src/config.py` still says `0.1.0`; tags reach v2.1.2).
+- **Where:** `src/config.py:15`, `sim-cpdlc.iss:5` (0.3.1), `version_info.txt:9-10,34,39` (0.1.0), `.github/workflows/build-and-release.yml:40-41`, `src/utils/update_checker.py:112-125, 143-150`.
+- **What is wrong:** `update_version.py` rewrites the three version strings only inside the release job and the result is never committed, so the tree disagrees with itself and with every release. `packaging.version.parse("2.1.2") > parse("0.1.0")`, so anyone running `python app.py` gets "A new version is available" a few seconds after start on every launch; answering Yes closes the app (M-5).
+- **Fix direction:** Make the tag the single source of truth and commit the bump (release workflow commits the `update_version.py` output, or the maintainer runs it before tagging), or derive `APP_VERSION` from `git describe` when not frozen and skip the auto-check for development versions. Keep the three strings identical.
+
+### M-11. Test fixtures are not hermetic: the real `config.json`, SimBrief and SimConnect are one call away
+
+- **Area:** Tests. **Confidence:** Confirmed (mechanisms); no current test trips them.
+- **Where:** `tests/test_main_window.py:60-64` (`window` fixture patches `load_config`, `_check_first_launch`, `wx.MessageBox` only), `tests/test_dialogs.py:13-25` (patches nothing), `tests/conftest.py:94-115` (`make_main_window`), `src/config.py:19-28` (real `CONFIG_FILE`, import-time `os.makedirs`), `src/gui/main_window.py:279` (`save_config` unpatched), `:1010, 1017` (real `load_config()` and `simconnect_manager` on every message from the current station), `connect_dialog.py:27,62`, `pdc_dialog.py:27,53` (real config, live SimBrief GET, modal box on failure).
+- **What is wrong:** Nothing redirects `src.config.CONFIG_FILE` to a temp path. The first test that drives `on_settings` to OK will `os.replace` the developer's real `config.json` with the patched defaults (wiping both logon codes and the SimBrief id). Constructing `ConnectDialog` or `PDCDialog` in a test reads the real config and, on this machine (SimBrief id set), performs a live HTTPS request and opens a modal box on failure, hanging the run. A HANDOVER/LOGOFF/CONTACT uplink through `make_main_window` reads the real config and, with `auto_tune_com1` true, dereferences the unset `simconnect_manager`; through the real `window` fixture it would drive the real SimConnect. `tests/README.md` says `test_dialogs.py` covers "each request dialog", inviting exactly those tests. Every test run also creates the real user-data directory at import time.
+- **Fix direction:** One autouse fixture: `CONFIG_FILE` → `tmp_path`; a `requests.get/post` guard that raises unless a test installed `serving()`; `get_latest_ofp` patched at both dialog import sites; a fake `SimConnectManager` and an injected config dict for `make_main_window`; assert `wx.GetTopLevelWindows()` is empty at `wx_app` teardown.
+
+### M-12. The acknowledgement RR/MIN, the MRN check and half the response table have no regression tests
+
+- **Area:** Tests. **Confidence:** Confirmed.
+- **Where:** `tests/test_acknowledge_path.py:21-28` (unpacks `_own_min, _rr` and asserts only recipient/text/MRN), `tests/test_logon_status.py:15-16` and `tests/conftest.py:46-48` (`uplink` never sets an MRN, so the helper named `mrn` builds `/data2/1//NE/LOGON ACCEPTED`), `tests/test_cpdlc_session.py` (only `mrn=None` or `mrn=1` against pending MIN 1), `tests/test_message_manager.py:93-109` (covers `WU`, `R`, `NE` only).
+- **What is wrong:** TODOS items 21, 22 and 24 (acks sent with `NE`, wrong `Y`/`N` response options, no MRN validation) are marked done but reverting any of them passes the suite: `RR.NO` on acknowledgements is never observed, the own MIN is discarded, the rejecting branch of the MRN check (`cpdlc_session.py:427-431`) is never entered, and `RR.YES → ["YES","NO"]`, `RR.NO → []`, `RR.AFFIRM_NEGATIVE` are untested. An unregistered WILCO is the single worst silent failure a CPDLC client can have.
+- **Fix direction:** Assert the full frame `(STATION, 1, RR.NO.value, "WILCO", 53)` plus one connector-level test capturing the literal `/data2/1/53/N/WILCO`; give `uplink` an `mrn` parameter and add the mismatch case; parametrise the response table over all six `CpdlcResponseRequirement` members.
+
+---
+
+## Low
+
+### L-1. "Connection problem (n/3) - retrying..." after a single failed send, until the next successful send
+- **Where:** `src/model/connection_manager.py:310-316`, `src/controller/polling_controller.py:205-217`. **Confidence:** Confirmed.
+- `poll_failed()` is `max(connection_failures, send_failures) > 0` and only a successful send clears `send_failures`, so one timed-out WILCO makes every subsequent good poll rewrite the status bar to a connection problem that is not happening; "Logged on to X." is lost. Report poll health from `connection_failures` only; keep the max for the reconnection decision.
+
+### L-2. A TELEX reading `LOGON ACCEPTED` / `LOGOFF` / `HANDOVER XXXX` drives CPDLC session state
+- **Where:** `src/gui/main_window.py:926-928, 946-1007`. **Confidence:** Confirmed (verified by execution: a `TelexMessage("EDGG", …, "logon accepted")` sets `current_station` to EDGG with no logon pending).
+- The session-state block is gated on `hasattr(get_packet_content/get_from_name)`, which every `HoppieMessage` satisfies; telex has no `get_mrn`, so the MRN check is skipped. Gate on `isinstance(message, CpdlcMessage)` (already imported, unused) and use `get_message()`/`get_mrn()`/`get_rr()` instead of re-parsing the packet.
+
+### L-3. Logon lifecycle has no negative paths
+- **Where:** `src/gui/main_window.py:956, 968-1007`, `src/model/cpdlc_session.py:396-451`. **Confidence:** Plausible.
+- Acceptance requires exactly `LOGON ACCEPTED`; a station appending anything leaves the app pending while the station considers it connected, and every later uplink from it is unanswerable. No handling of a rejection, no pending timeout, no periodic `ping(current_station)` to notice a controller who left without LOGOFF (common on VATSIM). Match on `startswith`, clear pending state on `LOGON REJECTED`/an `UNABLE` with the pending MRN, expire pending after a few minutes, ping the station occasionally.
+
+### L-4. Weather cycle has no deadline; an in-flight cycle survives reconnect and may mix credentials
+- **Where:** `src/model/weather_monitor.py:107, 120-125, 253-255, 262-269, 278-298`, `src/model/connection_manager.py:246-251, 264-270, 408-418`. **Confidence:** Confirmed.
+- A stuck request (per-read timeout, unbounded DNS) keeps `_cycle_running` true for the rest of the session, silently disabling updates while "Check now" says a check is running; ten subscriptions can exceed the 5-minute interval on a slow link. `stop()` sets a flag the worker samples once per subscription; disconnect and reconnect inside that window lets the old worker finish under the new session's credentials, and the worker reads `logon_code`/`callsign`/`network_type` one attribute at a time while the GUI thread writes them, so a mixed snapshot (one network's URL with the other's logon code) is possible. Use a cycle generation number checked in `_post_result`/`_on_result`, snapshot credentials on the GUI thread and pass them to the worker, and give the cycle a budget.
+
+### L-5. Worker-thread `IsBeingDeleted()` guards do not work and can raise at exit
+- **Where:** `src/model/weather_monitor.py:304, 310-311`, `src/utils/update_checker.py:48`, `app.py:47-51, 59-60`. **Confidence:** Confirmed mechanism, Plausible timing.
+- For a top-level frame the flag is set only inside the destructor (the deferred `Destroy()` does not set it), so from the worker the call is either "alive" or `RuntimeError: wrapped C/C++ object … has been deleted`; it is also a wx call from a non-GUI thread. At exit with a fetch in flight the worker dies, `threading.excepthook` calls `wx.CallAfter`, and once the `wx.App` is gone that raises `AssertionError('No wx.App created yet')` inside the excepthook. Use a Python-side flag set by `shutdown()`, wrap `wx.CallAfter` in the worker, and skip the dialog in the reporter when `wx.GetApp()` is None.
+
+### L-6. SimBrief diagnostics never reach the log file; the console handler is dead in the windowed build
+- **Where:** `src/utils/simbrief.py:8` (`getLogger(__name__)`), `src/logging_setup.py:12-27`, `connect_dialog.py:77-83`, `pdc_dialog.py:93-99`. **Confidence:** Confirmed (verified: the `src.utils.simbrief` logger has no handlers and root has none).
+- Every SimBrief failure reason (timeout, HTTP 400 for an unknown id, non-JSON) is logged to an orphan logger and the dialogs log only "Failed to fetch SimBrief OFP data"; the `except Exception` branches in the dialogs are unreachable because `fetch_ofp` swallows everything. In the frozen build `StreamHandler()` wraps a `None` stderr. Use the `"Sim-CPDLC"` logger (or a child), return an error string, and add the console handler only when `sys.stderr` is not None.
+
+### L-7. Input validation gaps in the request dialogs
+- **Where:** `altitude_change_dialog.py:72-85, 94-98`, `direct_request_dialog.py:62-68`, `speed_request_dialog.py:88-106`, `when_can_we_dialog.py:104-117`, `telex_dialog.py`. **Confidence:** Confirmed (verified: `int("35_0") == 350`, `int("+350") == 350`, full-width digits pass `isdigit()`; the library accepts `REQUEST FL35_0`).
+- Altitude uses `int()`, so `3_50` is transmitted as `REQUEST FL3_50` (while the pilot's own list shows `FL350`, because underscores are stripped for display), `+350` and Unicode digits fail later with "invalid characters", and two-digit levels go out unpadded. Direct-to rejects legitimate fixes with digits (`55N020W`, `5530N`) and anything over five characters, while `isalpha()` admits non-ASCII letters. Speed/When-can-we use `isdigit()` (Unicode digits pass) and the Mach/knots branches are identical (`M820` accepted). Telex gives no feedback about the 220-character/ASCII limits until after OK. Validate with ASCII regexes (`^\d{2,3}$`, `^[A-Z0-9]{2,7}$`), zero-pad levels, show remaining characters in Telex.
+
+### L-8. Unredacted logon code survives in the exception chain; DEBUG logging prints both logon codes
+- **Where:** `src/model/connection_manager.py:137, 141-143, 181` (`raise … from exc`), `app.py:39-42`, `src/controller/polling_controller.py:171`, `src/config.py:52, 85`. **Confidence:** Confirmed (verified: `str(exc)` is clean, `traceback.format_exception(exc)` contains the code via `__cause__`).
+- `redact()` scrubs the message but the original `requests` exception with `?logon=…` is kept as `__cause__`, which traceback formatting prints in full; every `HoppieError` is caught today, so this is dormant but one `logger.exception` away. `Loaded config`/`Saved config` debug lines include both logon codes, at exactly the level a user would be asked to enable for troubleshooting. Raise with `from None` (or a redacted cause), redact the config dict before logging, run `redact()` in the global handler's log line.
+
+### L-9. `on_disconnect` sleeps 500 ms on the GUI thread for nothing and re-arms polling before stopping it
+- **Where:** `src/gui/main_window.py:383-391`. **Confidence:** Confirmed. `send_cpdlc` is synchronous, so the "small delay to allow the message to be sent" only freezes the loop; `set_active_polling()` three lines before `stop()` is a no-op pair. Delete both.
+
+### L-10. Settings applies the weather interval before the save succeeds
+- **Where:** `src/gui/main_window.py:277-292`. **Confidence:** Confirmed. `set_interval` runs before `save_config`; on failure the session and the file disagree and the success text ("used for future operations") is inaccurate either way. Apply runtime changes inside the success branch.
+
+### L-11. `resource_path` resolves against the current directory in development mode
+- **Where:** `src/gui/main_window.py:56-64, 82-89`. **Confidence:** Confirmed. `python C:\…\app.py` from another directory shows the missing-sound warning on every start and plays no sound. Use the directory of `app.py`.
+
+### L-12. `@@` becomes `N/A` glued to neighbouring words; list columns never resized
+- **Where:** `src/utils/message_formatting.py:25-30, 39-41`, `src/gui/message_view.py:56-62`. **Confidence:** Confirmed (verified: `FL360@@REPORT LEVEL` → `FL360N/AREPORT LEVEL`, read by NVDA as "FL360N slash AREPORT"). Pad the substitution or drop it; columns are `LIST_AUTOSIZE`d once while empty (Plausible).
+
+### L-13. `dlg.Destroy()` is skipped when anything raises between `ShowModal()` and the end of the handler
+- **Where:** every `ShowModal … Destroy` pair in `src/gui/main_window.py` (259-296, 320-347, 417-449, 513-533, 554-570, 591-609, 630-646, 673-690, 720-754, 810-840). **Confidence:** Confirmed. The unconverted local `OSError`s are exactly what can raise there. Use `with Dialog(...) as dlg:` or `try/finally`.
+
+### L-14. Exception reporter opens a modal inside the failing handler; `OnExceptionInMainLoop` and the Ctrl+C branch are dead or wrong
+- **Where:** `app.py:31-51, 53-57, 66-76, 100-107`. **Confidence:** Confirmed.
+- Python exceptions in wx handlers are already routed to `sys.excepthook` by wxPython; `OnExceptionInMainLoop` only runs for C++ exceptions, where `sys.exc_info()` is all `None` and `issubclass(None, KeyboardInterrupt)` raises `TypeError`. `wx.App()` defaults to `clearSigInt=True` (SIGINT → `SIG_DFL`), so Ctrl+C kills the process and the `KeyboardInterrupt` branch never runs (and would call `on_exit` on a possibly destroyed frame). The synchronous `wx.MessageBox` in the reporter lets timers re-enter under it (see M-4). Guard on `exc_type is not None`, decide on `clearSigInt`, show the report via `wx.CallAfter` and coalesce.
+
+### L-15. `_confirm_exit` ignores `CanVeto()`; first-launch prompt runs mid-`__init__`
+- **Where:** `src/gui/main_window.py:1077-1079, 1111-1121, 79, 1142-1153`. **Confidence:** Confirmed. On a forced close (Windows end-session) the confirmation still blocks and `Veto()` trips a wx assertion, skipping cleanup. The welcome dialog runs a modal loop before `_init_ui`, before `EVT_CLOSE` is bound and before the controllers exist; safe today only because nothing else can run in that loop (the follow-up `on_settings` is correctly deferred). Check `CanVeto()`; schedule the first-launch prompt after construction.
+
+### L-16. Weather subscriptions dialog gives no confirmation on stop and can list stale entries
+- **Where:** `src/gui/dialogs/weather_subscriptions_dialog.py:94-104, 131-157`. **Confidence:** Confirmed. The other two stop paths add a SYSTEM row and status text; this one only removes the row. `_on_result` runs during the dialog's modal loop, so a subscription dropped after five failures stays listed until the next refresh. Route through the same helper; refresh from `on_error`/`on_update`.
+
+### L-17. Smaller protocol and parsing points
+- **Where:** `src/model/connection_manager.py:443-446`; `src/gui/main_window.py:970`; `src/utils/frequency_parser.py:7-14`; `src/controller/polling_controller.py:261-291`. **Confidence:** Confirmed (parser cases verified by execution).
+- `error {no data}` is surfaced as "METAR request error: {no data}" (braces kept). `^HANDOVER\s+([A-Z]{4})$` handles `HANDOVER @EDYY@` but any trailing text defeats it (the message is still shown). `extract_contact_frequency("CONTACT 121.500")` returns None because the pattern demands a unit name; realistic texts with a unit name all parse, and the DOTALL comment is inaccurate. Every non-acknowledgement uplink, including `LOGON ACCEPTED`/`LOGOFF`/`HANDOVER`, starts five minutes of 20 s polling, while an ATC `STANDBY`/`ROGER` does not extend the window even though a reply is then expected.
+
+### L-18. README and docs drift
+- **Where:** `README.md:20, 28-30, 84-91, 109-110`, `tests/README.md:17-30`, `app.py:3`. **Confidence:** Confirmed (`hoppie_connector-0.2.1` METADATA: `Requires-Python: >=3.12`; the library uses `StrEnum`, `typing.Self`, `match`).
+- "Python 3.7 or higher" is wrong by five minor versions (pip fails on anything below 3.12; CI uses 3.13). The altitude section describes a climb/descent choice the dialog does not have. "The report is added … and the notification sound plays" contradicts the deliberate quiet policy for requested reports. "Automatic Reconnection" overstates H-2. The tests table omits `test_config.py` and `test_weather_parsing.py` and claims dialog and downlink coverage that does not exist. `app.py`'s docstring names only SayIntentions.
+
+### L-19. Packaging and requirements
+- **Where:** `requirements.txt:2, 7`, `app.spec:11-18, 35`, `.gitignore`, `.github/workflows/build-and-release.yml`, `.github/workflows/tests.yml`. **Confidence:** Confirmed.
+- `pyinstaller==6.20.0` sits in the runtime requirements. `SimConnect>=0.4.26` is the only unpinned dependency, and `app.spec` bundles `SimConnect.dll` only if it happens to be present, so a build machine without it ships an installer whose auto-tune never works, with only a PyInstaller warning. `.gitignore` lacks `installer/` and `.pytest_cache/`. The release workflow does not run the test suite and `fetch-depth: 0` is unused; the test job has no `timeout-minutes`, so an unstubbed modal dialog hangs it for six hours. The three checked-in version strings differ (0.1.0 / 0.3.1 / 0.1.0).
+
+### L-20. Personal SimBrief data and a live-API script committed under `src/`
+- **Where:** `src/utils/latest_simbrief_ofp.json` (164 KB, since the initial commit: real name, SimBrief user id, full OFP), `src/utils/test_simbrief.py:20, 42-47` (hard-coded id 189007, overwrites the JSON, one `pytest src` away from being collected). Neither is used by the application. Delete or move to `tools/` reading the id from the environment; ignore the output file.
+
+### L-21. Test-suite weaknesses (beyond M-11/M-12)
+- **Confidence:** Confirmed. Details and a full coverage map are in the tests report (appendix).
+- `test_every_menu_item_has_a_handler` checks only that methods exist; deleting a `Bind` passes. `test_menu_shown_for_a_message_from_the_current_station` asserts only that a menu popped, never its items, the closure capture or the post-popup `Unbind` (TODOS 2). `test_context_menu_follows_the_session_after_a_handover` never opens a context menu. `test_repeated_failures_drop_the_subscription` cannot tell `MAX_CONSECUTIVE_ERRORS == 5` from `== 1`. The weather monitor's real thread path is exercised only incidentally by `test_check_now_says_a_cycle_started`, which returns while the worker is still running. The two `install_request_timeout` tests monkeypatch only `requests.get`, leaving `requests.post` permanently wrapped for the rest of the session. `from conftest import …` relies on pytest's default import mode. The `wx.MessageBox` stub returns `None`, so every future "!= wx.YES" confirmation silently cancels. Weak assertions: `status_texts != []`, `timeout is not None`, inforeq params never asserted.
+- **Untested (highest risk first):** `on_connect`/`on_disconnect`/`on_close`; PollingController reconnection branch and `_report_connection_state`; HANDOVER, LOGOFF and CONTACT branches of `_on_message_received`; `CpdlcSession.logon`/`logoff`/`send_speed_request`/`send_pdc_request`/all failure paths (`FakeConnectionManager` never raises); `load_config`/`save_config`; `frequency_parser`, `message_formatting`, `simconnect_manager`, `update_checker`; nine of ten dialogs; `WeatherMonitor.set_interval`, re-subscribe with new text, error-count reset; `on_message_selected`.
+
+---
+
+## Info
+
+### I-1. Unused imports and dead code
+`src/gui/main_window.py:9-14` (`CpdlcMessage`, `RR`, `HoppieMessage`), `src/model/cpdlc_session.py:3-4` (`logging`, `Callable`), `src/controller/polling_controller.py:5` (`logging`) — all verified by AST scan. `MessageManager.get_weather_key` and `MessageView.clear` have no callers. `PollingController.default_poll_interval` is stored and never read (the docstring describes a path that cannot occur). `ConnectionManager.message_callback` is unused. `poll_status` is actually a `timedelta` and is discarded. `extract_atis_letter`'s `icao` parameter is dead. The "Always enable both logon and logoff menu items" comment describes removed code.
+
+### I-2. Duplication the PR-24 spec left open, still open
+Seven handlers hand-roll the "Not Connected" box although `_require_connection` exists (used once); five hand-roll "Not Logged On". `send_altitude_change_request`, `send_direct_request`, `send_speed_request`, `send_when_can_we_expect` differ only in the text. `_on_message_received` repeats the extract/normalise block twice and re-parses packets that `CpdlcMessage.get_message()` already exposes. `_check_first_launch` re-imports `os`, `load_config`, `save_config` locally (a local import that would also bypass the test monkeypatch).
+
+### I-3. Indirection with no purpose
+`send_logoff_message` is an alias "for backward compatibility" in an app with no external callers. `MainWindow.get_current_station` wraps the session behind a check equivalent to the session's own; its one consumer, `TelexDialog`, reaches into `parent.get_current_station()` instead of taking the value as an argument. `resource_path` is an instance method that never uses `self`.
+
+### I-4. Accessibility conventions are applied unevenly
+Mnemonics and `SetName` only in the weather dialogs and the Settings spin control; `ConnectDialog`'s `RadioBox` has an empty label with a separate static text; helper texts use a hard-coded grey `wx.Colour(100,100,100)` that ignores high-contrast themes; accelerators reuse OS conventions (`CTRL+S`, `CTRL+W`, `CTRL+O`). Menu mnemonic uniqueness is tested; dialogs are not.
+
+### I-5. Miscellaneous
+`check_polling_timeout` uses wall-clock `time.time()`. `cpdlc_min_counter` never wraps (FANS-1/A MIN is modulo 64; whether Hoppie ATC clients care is unverified). Hoppie's own change log says VATSIM/IVAO ATIS is cached for five minutes server-side, so a 1-minute ATIS interval buys nothing against Hoppie. No `requests.Session`, so every call is a fresh TLS handshake (fine at these rates). Type hint `sender: str = None` should be `Optional[str]`. About dialog copyright year is fixed at 2025. The stale review worktree `.claude/worktrees/review-25-ceb148` (excluded via `.git/info/exclude`) holds the only local environment with the app's dependencies.
+
+---
+
+## Recommended new tests (prioritised)
+
+1. Full acknowledgement frame `(STATION, 1, RR.NO.value, "WILCO", 53)` and a connector-level `/data2/1/53/N/WILCO` capture (M-12).
+2. Hermetic conftest: `CONFIG_FILE` → `tmp_path`, network guard, SimBrief patched, fake SimConnect, empty top-level-window assertion (M-11).
+3. HANDOVER through the window: station cleared, `("EDGG", 1, "Y", "REQUEST LOGON", None)` sent, both status texts, active polling bumped; negative from a non-current station.
+4. LOGOFF and `LOGOFF NOT REQUIRED…` from the current station (TODOS 23); `CURRENT ATC UNIT` filter.
+5. CONTACT auto-tune with a fake SimConnect: tuned / disabled / failed-status / non-current station.
+6. Telex bodies never drive session state (L-2).
+7. PollingController link reporting and both reconnection outcomes, exact status texts, `is_running()` afterwards.
+8. MRN mismatch rejection; response table over all six RR members.
+9. Context menu labels, item firing, no stale binding after close.
+10. Every downlink literally, plus every failure path via a raising fake.
+11. Weather monitor with a synchronous thread stub: announce once, second `check_now()` refused, error-count reset, re-subscribe re-seeds, `set_interval` restarts.
+12. Per-dialog OK-button tables and getter literals; `load_config`/`save_config` on `tmp_path`; `frequency_parser` and `message_formatting` tables; `on_connect`/`on_disconnect`/`on_close` through the real window with dialogs stubbed.
+
+---
+
+## Verified as sound
+
+- `install_request_timeout()` reaches the library: `hoppie_connector/API.py` calls `requests.get`/`requests.post` as module attributes; both arrived with `timeout=15` (verified by execution). No outbound call lacks a timeout.
+- Error classification at the boundary (transport vs protocol vs `OSError` pass-through), the three separate failure counters, and `should_attempt_reconnection` requiring a live `cnx` behave as the tests describe. `redact()` covers every `HoppieError` message built in `_call`; no f-string formats the logon code; both URLs are HTTPS.
+- RR values on downlinks match real Hoppie traffic (`Y` for logon/requests, `NE` for LOGOFF, `N` with `mrn` for acknowledgements); MIN advances only on successful sends. LOGON ACCEPTED validation against the pending station and MRN is right; unsolicited acceptances still work; `extract_message_content` strips every prefix shape the library emits.
+- Polling rate: idle re-randomised in 45–75 s per tick, 20 s active, one-shot re-armed in `finally`, `set_active_polling` only pulls a poll forward; no path polls faster than 20 s; the 15 s timeout and post-failure back-off comply with Hoppie's published request ("skip this attempt and come back after your normal random delay").
+- WeatherMonitor ownership model (GUI-thread state, snapshot to worker, results via `CallAfter`, `_on_cycle_finished` posted last), timer lifecycle across start/stop/shutdown/start, `check_now()` reporting, `_on_result` tolerance of unsubscribe-in-flight, interval clamping.
+- MessageView context menus: per-item bind/unbind around `PopupMenu`, lambda defaults, no accumulation (TODOS 2 fixed); message encodings round-trip; every message type `poll()` can return is displayable and only `CpdlcMessage` is answerable.
+- `on_close` ordering, `Skip()`/`Veto()` pairing on normal paths, `config.py` atomic write and error handling, packaging paths in `app.spec`/`.iss`/`update_version.py`, the `global` statement in `simconnect_manager.py`, and every item previously recorded as fixed in `TODOS.md` and the PR-24 spec.
+
+---
+
+## Questions before planning fixes
+
+1. **H-1 calibration.** Do your own Hoppie message logs (the web log for a past flight versus `sim-cpdlc.log`) show CPDLC uplinks containing `/ , : - ( )` or lowercase text? That decides whether H-1 needs a permissive parser or just logging plus a SYSTEM row.
+2. **Reconnection policy (H-2).** Keep retrying with back-off indefinitely while showing the state, or stop after N minutes? Should a lost/restored connection play the notification sound?
+3. **Session state across reconnects (M-1).** When reconnecting with the *same* callsign, should the ATC logon be kept (current behaviour, arguably correct for Hoppie) and only be reset when the callsign or network changes?
+4. **Threading scope (H-3).** Move all CPDLC I/O to a worker now, or start with the cheap wins (SimBrief out of constructors, manual weather and update check threaded, split timeouts)?
+5. **Update checker (M-5/M-10).** Is "Yes closes the app" intended? Should development runs (version 0.1.0 or a `git describe` string) skip the automatic check?
+6. **`@@` → `N/A` (L-12).** Is that substitution still matched by observed traffic, or should empty placeholders simply collapse?
+7. **Manual logon while logged on (M-7).** Refuse, or send LOGOFF to the current station first?
+8. **Python floor (L-18).** Document 3.12 (the library's minimum) or 3.13 (what CI runs)?
+
+---
+
+## Appendix: verification performed
+
+- Baseline: `python -m pytest -q -p no:cacheprovider` → 135 passed in 1.21 s (worktree venv; global Python 3.14 has none of the dependencies).
+- Execution checks (scratchpad scripts, in-process fakes, no network): library parse whitelist and `poll()` warning behaviour (H-1); ASCII decode failure through `ConnectionManager.poll()` (M-2); inforeq envelope cases `ok {server info {}}`, `ok`, `ok {server info { }}`, `error {no data}`, HTML (M-6); timeout monkeypatch reaching the library; frequency-parser cases; `extract_message_content` cases; `int()`/`isdigit()` validation edge cases and library acceptance of `REQUEST FL35_0` (L-7); SimBrief logger handlers (L-6); AST scan for unused imports (I-1); `wx.CallAfter` without an App (L-5); telex-driven `LOGON ACCEPTED` (L-2); `OSError` escaping `attempt_reconnection` (M-4); `__cause__` retaining the logon code (L-8); `@@` formatting (L-12); `Requires-Python` of the pinned library and `APP_VERSION` at tags v2.0.0/v2.1.2 (L-18, M-10).
+- External references: Hoppie ACARS technical page (poll timing and 15 s guidance; no character-set rule published); upstream Python-SimConnect source (`send_event` returns False, `map_to_sim_event` returns None, daemon dispatch thread, no retry on open).
+- Lens reports with full detail (including the complete test coverage map): `docs/audit/lens/2026-09-03-threading-lifecycle.md`, `docs/audit/lens/2026-09-03-network-protocol.md`, `docs/audit/lens/2026-09-03-gui-state-config.md`, `docs/audit/lens/2026-09-03-test-suite.md`.

--- a/docs/audit/lens/2026-09-03-gui-state-config.md
+++ b/docs/audit/lens/2026-09-03-gui-state-config.md
@@ -1,0 +1,319 @@
+# Sim-CPDLC audit — GUI logic, state consistency, configuration/packaging, input validation, accessibility, code quality
+
+Read-only audit of `C:\Claude\sim-cpdlc` at commit `9c06458` (main, 2026-09-03). Every file under `src/`, `app.py`, `tests/`, the project/packaging files and `hoppie_connector` 0.2.1 (`__init__.py`, `API.py`, `Messages.py`, `Utilities.py`, `CPDLC.py`, `Responses.py`) were read in full. Regex and validation claims below were confirmed by running the pure functions with the review venv interpreter (Python 3.14, wxPython 4.2.5 msw / wxWidgets 3.2.9); nothing GUI-side was launched.
+
+No finding in this lens rises to Critical or High: the state machine is mostly sound, and the earlier review items in TODOS.md and the PR-24 spec are fixed as claimed (including the "out of scope" items for `check_now()`, the weather-interval clamp, the fixture window leak and the per-report request methods, all closed by later commits). The remaining "out of scope" duplication items (hand-rolled guards, four near-identical `CpdlcSession` senders) are still open and listed under Info.
+
+---
+
+## Medium
+
+### M1. After an automatic reconnection fails, the File menu still says "Disconnect" and there is no "Connect" to reach
+- **Severity**: Medium — the status bar tells the user to reconnect, but the only menu entry is labelled the opposite; for an NVDA user that is a dead end unless they guess.
+- **Confidence**: Confirmed
+- **Location(s)**: `src/controller/polling_controller.py:182-196`, `src/gui/main_window.py:307-314`, `:341-342`, `:397-398`, `src/model/connection_manager.py:347-350`; also `polling_controller.py:69, 90-107, 205-217`
+- **What is wrong**: `PollingController.on_poll_timer` handles the reconnection-failure branch entirely on its own: it sets the status text, stops the timer, and `attempt_reconnection()` has already set `cnx = None`. Nothing notifies `MainWindow`, and `menu_item_connect` is relabelled only inside `on_connect`/`on_disconnect`. The item therefore keeps the label "&Disconnect" and help text "Disconnect from the CPDLC network" while `is_connected()` is False. Because `on_connect_or_disconnect` dispatches on `is_connected()`, activating "Disconnect" actually opens the Connect dialog, so recovery is possible but only by doing the opposite of what the menu says. Secondary: `_reported_failure` is never reset by `start()`, so the first successful poll after the manual reconnect overwrites "Connected as X." with "Connection restored.".
+- **Failure scenario**: Link drops → three failed polls → "Connection problem (3/3) - retrying..." → reconnection fails → status "Connection lost. Reconnect to continue." → user opens File: entries are Disconnect / Settings / Check for Updates / About / Exit. A screen-reader user hearing "Disconnect" has no reason to activate it; a sighted user sees a contradiction. If they do activate it, the Connect dialog appears.
+- **Evidence**:
+  ```python
+  # polling_controller.py:191-196
+  self.logger.error("Reconnection failed")
+  self._set_status("Connection lost. Reconnect to continue.")
+  self.stop()
+  # main_window.py:341 (only place the label becomes Disconnect) / :397 (only place it becomes Connect again)
+  self.menu_item_connect.SetItemLabel("&Disconnect")
+  ```
+- **Suggested fix direction**: Give `PollingController` an `on_connection_lost` callback (or have it call a `MainWindow._on_connection_lost()` that resets the menu label/help, stops the weather monitor, and adds a SYSTEM message), and reset `_reported_failure` in `start()`. Alternatively derive the label from `is_connected()` in an `EVT_UPDATE_UI` handler.
+
+### M2. A LOGOFF that fails to send during Disconnect/Exit is silently ignored, and the session's logon state is never reset across a disconnect/reconnect
+- **Severity**: Medium — the app tells the user "you will be logged off", proceeds without saying it could not, and afterwards routes requests and offers response menus for a station it is not connected to.
+- **Confidence**: Confirmed
+- **Location(s)**: `src/gui/main_window.py:379-386`, `:1084-1087`, `:316-347` (`on_connect` never touches `cpdlc_session`), `src/model/cpdlc_session.py:116-141` (`logoff` leaves `current_station` on failure), `:27-28, 100-101, 435-436` (`pending_logon_*` cleared only by acceptance), `src/model/connection_manager.py:256-271` (clears its own fields only)
+- **What is wrong**: `on_disconnect` calls `send_logoff_message()` and inspects `success` only to decide whether to log the sent text; a `False` result (the common case when the reason for disconnecting is a dead link) produces no dialog, no SYSTEM message, and `current_station` stays set. `ConnectionManager.disconnect()` is careful to clear everything `connect()` set, but there is no equivalent for `CpdlcSession`: `current_station`, `pending_logon_min/station` and `callsign` survive the disconnect and the next `connect()`. `is_logged_on()` then reports True on a fresh connection.
+- **Failure scenario**: Logged on to EDDF, link dies → user chooses File > Disconnect → confirmation says "you will be logged off from this station" → LOGOFF send raises `HoppieError` → silently dropped → "Disconnected from CPDLC network." → later File > Connect as a different callsign or on the other network → status "Connected as X." but Requests > Altitude change is accepted and transmitted to EDDF (`send_altitude_change_request` only checks `current_station` and `is_connected()`), the context menu on old EDDF uplinks still offers WILCO/UNABLE, and the next Disconnect/Exit confirmation again claims "logged on to EDDF". Same for `on_close` (1084-1087), where the failure is invisible in the log too because only `cpdlc_session` logs it.
+- **Evidence**:
+  ```python
+  # main_window.py:379-382
+  if self.cpdlc_session.is_logged_on():
+      success, message = self.cpdlc_session.send_logoff_message()
+      if success and message:
+          self._add_custom_message(message)
+  # cpdlc_session.py:130-134 — failure path returns before current_station is cleared
+  except HoppieError as exc:
+      ...
+      return False, str(exc)
+  ```
+- **Suggested fix direction**: Add `CpdlcSession.reset()` (clear `current_station`, `pending_logon_*`, restart `cpdlc_min_counter`) and call it from `on_disconnect` after the LOGOFF attempt and from `on_connect` before `set_callsign`. In `on_disconnect`, surface a failed LOGOFF as a SYSTEM message ("Could not send LOGOFF to EDDF: …") so the user knows ATC was not told.
+
+### M3. README says Python 3.7+, but the pinned `hoppie-connector` requires Python 3.12+
+- **Severity**: Medium — the only prerequisite stated for the documented "Install from Source" path is wrong by five minor versions; the install fails before the app can start.
+- **Confidence**: Confirmed
+- **Location(s)**: `README.md:28-30`, `requirements.txt:1`, `app.py:63`, `.github/workflows/tests.yml:21`, `.github/workflows/build-and-release.yml:24`
+- **What is wrong**: `hoppie_connector-0.2.1.dist-info/METADATA` declares `Requires-Python: >=3.12`, and its source uses `str | None` (3.10), `match` (3.10), `enum.StrEnum`, `typing.Self`, `datetime.UTC` (all 3.11). `app.py` also relies on `threading.excepthook` (3.8). CI runs on 3.13. On Python < 3.12 `pip install -r requirements.txt` reports "No matching distribution found for hoppie-connector==0.2.1".
+- **Failure scenario**: A user on Python 3.9–3.11 follows README steps 1–3 and gets a pip resolution error with no hint that the README's version claim is the cause.
+- **Evidence**: `README.md:30`: `- Python 3.7 or higher`; METADATA: `Requires-Python: >=3.12`.
+- **Suggested fix direction**: State "Python 3.12 or higher" (matching what CI tests), and consider adding a `python_requires`-style check at the top of `app.py` that prints a clear message.
+
+### M4. A source checkout identifies itself as version 0.1.0, so every launch shows a bogus "update available" dialog whose "Yes" closes the app
+- **Severity**: Medium — happens on every start of the documented source install (until the user finds and disables auto-check); the affirmative answer terminates the program.
+- **Confidence**: Confirmed
+- **Location(s)**: `src/config.py:14-15`, `src/utils/update_checker.py:25, 112-125, 143-150`, `.github/workflows/build-and-release.yml:40-41`, `sim-cpdlc.iss:5`, `version_info.txt:9-10, 34, 39`
+- **What is wrong**: `APP_VERSION = "0.1.0"` is what is checked in, and it is "0.1.0" at every tag from v2.0.0 to v2.1.2 (verified with `git show <tag>:src/config.py`); `update_version.py` rewrites it only inside the release workflow, and the change is never committed back. The three checked-in version strings also disagree with each other (config 0.1.0, `.iss` 0.3.1, `version_info.txt` 0.1.0) and with the latest release tag v2.1.2. `packaging.version.parse("2.1.2") > parse("0.1.0")` is True, so `_is_newer_version` always fires for anyone running `python app.py`.
+- **Failure scenario**: `git clone` → `python app.py` → after a few seconds "A new version of Sim-CPDLC is available! Current version: 0.1.0 / Latest version: 2.1.2" → Yes → browser opens the release page and `wx.CallAfter(self.parent.Close)` closes the app the user just started. About dialog shows 0.1.0, so bug reports from source users carry a useless version.
+- **Evidence**: `config.py:15`: `APP_VERSION = "0.1.0"`; `update_checker.py:150`: `wx.CallAfter(self.parent.Close)`.
+- **Suggested fix direction**: Make the tag the single source of truth and commit the bump (release workflow commits `update_version.py` output, or the maintainer runs it before tagging), or derive `APP_VERSION` from `git describe` when not frozen and skip the auto-check when the version is a development one. Keep the three strings identical in the tree.
+
+### M5. Dialogs validate on stripped text but return unstripped text, so an invisible leading/trailing space passes the OK gate and then fails with a confusing error
+- **Severity**: Medium — affects the most common flows (Logon, Telex, PDC, Connect); the stray space is exactly what a screen-reader user cannot see, and the resulting message contradicts the dialog that just accepted the input.
+- **Confidence**: Confirmed (library rejects `" EDDF"`/`"EDDF "`: `Invalid TO station name`; `on_logon` rejects with its own message)
+- **Location(s)**: `src/gui/dialogs/logon_dialog.py:44-60`, `telex_dialog.py:52-74`, `pdc_dialog.py:137-171`, `connect_dialog.py:167-214`, `settings_dialog.py:171-186`; consumer `src/gui/main_window.py:418-428`
+- **What is wrong**: Every `on_text_change` calls `.strip()` before checking length/emptiness, but the `get_*_details()` methods return `GetValue().upper()` (or raw `GetValue()`) without stripping. `hoppie_connector` validates station names with `^[A-Z0-9]{3,8}$` (Utilities.py:4) so any whitespace is fatal at send time. The Logon dialog is the worst case: "EDDF " enables OK, then `on_logon` measures `len(station) != 4` on the unstripped value and shows "Station name must be exactly 4 characters long." even though the user typed four letters. Settings saves logon codes with surrounding whitespace, which then makes every connection fail with the server's "invalid logon" until the user notices.
+- **Failure scenario**: Requests > Logon, type "EDDF" followed by an accidental space, OK is enabled, press Enter → "Invalid Station Name: must be exactly 4 characters long". Telex: recipient "EDDF " → "Failed to send telex message to EDDF : Invalid TO station name." PDC: origin " EDDF" → "Failed to send PDC request to  EDDF: Invalid TO station name." Connect: callsign "DLH123 " → "Connection failed: Invalid FROM station name".
+- **Evidence**:
+  ```python
+  # logon_dialog.py:48 vs :60
+  if len(self.station_text.GetValue().strip()) == 4:
+  ...
+  return self.station_text.GetValue().upper()
+  ```
+- **Suggested fix direction**: Strip in every getter (and in `SettingsDialog.get_settings`), or normalise once in the dialogs' `EVT_TEXT` handler. `on_logon`'s length re-check then becomes redundant.
+
+### M6. SimBrief is fetched synchronously inside the Connect and PDC dialog constructors, freezing the GUI (up to 10 s) before the dialog even appears
+- **Severity**: Medium — a blind user gets silence for up to 10 s after choosing Connect, with no indication anything is happening; it repeats on every open of either dialog.
+- **Confidence**: Confirmed
+- **Location(s)**: `src/gui/dialogs/connect_dialog.py:56-90`, `pdc_dialog.py:47-106`, `src/utils/simbrief.py:28-32` (`timeout=10`); related: `src/utils/update_checker.py:38-40, 53-78, 97` (manual check, synchronous, 5 s), `src/gui/main_window.py:734` (manual weather request, synchronous, 15 s)
+- **What is wrong**: `get_latest_ofp()` performs a blocking `requests.get` from `__init__`, before `ShowModal`. While it runs, the main window does not repaint and NVDA reports nothing. The automatic weather path already uses a worker thread for the same class of call, so the synchronous manual weather request and the synchronous manual update check are inconsistent with it. (Polls/sends being synchronous with the 15 s `NETWORK_TIMEOUT` is documented design and not counted here, but it means a dead link can freeze the UI for 15 s per poll during an outage.)
+- **Failure scenario**: SimBrief slow or unreachable (or a wrong user id producing a slow 4xx) → File > Connect → no dialog, no sound, no focus change for up to 10 s → then a "Could not fetch flight plan from SimBrief." warning box → then the Connect dialog.
+- **Evidence**: `connect_dialog.py:62`: `ofp_data = get_latest_ofp(simbrief_userid)` inside `__init__`.
+- **Suggested fix direction**: Show the dialog first and fill the callsign/ICAO fields from a worker thread via `wx.CallAfter` (disable OK or show "Fetching SimBrief…" in the meantime), or cache the OFP per session. Same pattern for the manual update check and manual weather request.
+
+---
+
+## Low
+
+### L1. Altitude dialog validates with `int()`, which accepts `+350`, `3_50`, full-width/Arabic digits and unpadded two-digit levels
+- **Severity**: Low — malformed input reaches the wire in one case and produces confusing library errors in others; needs unusual typing.
+- **Confidence**: Confirmed (run: `int("3_50") == 350`, library accepts `REQUEST FL3_50`, rejects `FL+350` and `FL٣٥٠`)
+- **Location(s)**: `src/gui/dialogs/altitude_change_dialog.py:72-85, 94-98`
+- **What is wrong**: `int(altitude)` tolerates a sign, underscores and any Unicode decimal digits; the raw text is then prefixed with "FL". `CpdlcMessage` allows underscores (`[A-Z0-9\.\_\@ ]`), so `3_50` is transmitted as `REQUEST FL3_50`, while `format_list_text` strips underscores for display, so the pilot's own message list shows `REQUEST FL350`. `+350`/Unicode digits pass the dialog and fail in the library with "Message contains invalid characters". Two-digit levels are sent as `FL50` rather than `FL050`.
+- **Failure scenario**: Type "3_50" (or paste) → OK enabled → controller receives `REQUEST FL3_50`; the sender sees `REQUEST FL350` locally and cannot tell what went wrong.
+- **Evidence**: `altitude_change_dialog.py:79`: `fl = int(altitude) if altitude else 0`
+- **Suggested fix direction**: Validate with a regex `^\d{2,3}$` on ASCII digits (`str.isascii() and str.isdigit()`), and zero-pad to three digits.
+
+### L2. Direct-to dialog rejects legitimate fixes containing digits, while accepting non-ASCII letters the library rejects
+- **Severity**: Low — blocks a valid request class (lat/long or alphanumeric waypoints) but the pilot can fall back to a telex.
+- **Confidence**: Confirmed (`"55N020W".isalpha()` False; `"ÄBCDE".isalpha()` True; library accepts `REQUEST DIRECT TO 55N020W`, rejects `ÄBCDE`)
+- **Location(s)**: `src/gui/dialogs/direct_request_dialog.py:28-30, 62-68`
+- **What is wrong**: `2 <= len(fix) <= 5 and fix.isalpha()` excludes oceanic lat/long positions (`55N020W`, `5230N`), alphanumeric terminal waypoints (`DF123`, `OM25L`) and anything longer than five characters, none of which the CPDLC element or the library forbids; `isalpha()` meanwhile admits Unicode letters that fail at send time.
+- **Failure scenario**: Oceanic flight wants "REQUEST DIRECT TO 55N020W" → OK never enables → no way to send it except free-text telex.
+- **Evidence**: `direct_request_dialog.py:65`: `if 2 <= len(fix) <= 5 and fix.isalpha():`
+- **Suggested fix direction**: Accept `^[A-Z0-9]{2,7}$` (ASCII) and update the helper text.
+
+### L3. Speed / When-can-we dialogs use `str.isdigit()`, which admits non-ASCII digits; Speed dialog's Mach and knots branches are identical
+- **Severity**: Low — edge input; the library error is at least shown.
+- **Confidence**: Confirmed (`"٣٠٠".isdigit()` True)
+- **Location(s)**: `src/gui/dialogs/speed_request_dialog.py:88-106`, `when_can_we_dialog.py:113-117`
+- **What is wrong**: Unicode digits pass validation and fail in `CpdlcMessage`; the Mach/knots branches (95-106) contain the same check twice, so the comment "Mach: 2-3 digits" vs "Knots: 2-3 digits" documents a distinction the code does not make. Mach `820` is accepted and sent as `REQUEST M820`.
+- **Evidence**: `speed_request_dialog.py:91`: `if not speed.isdigit():`
+- **Suggested fix direction**: `speed.isascii() and speed.isdigit()`; collapse the branches; consider `0\d\d` for Mach.
+
+### L4. `_check_first_launch` posts `on_settings` before the collaborators it uses exist; correct today only by event-loop ordering
+- **Severity**: Low — currently safe on the normal path; fragile.
+- **Confidence**: Plausible (whether the pending event can run inside the native missing-sound `wx.MessageBox` at :88 was not verified; if it can, the first-launch settings save raises `AttributeError: weather_monitor` and the settings are not saved)
+- **Location(s)**: `src/gui/main_window.py:79, 82-89, 115-123, 237-296 (278), 1125-1161 (1158)`
+- **What is wrong**: `__init__` calls `_check_first_launch()` (which does `wx.CallAfter(self.on_settings, None)`) before `_init_ui()`, before `update_checker`, and before `self.weather_monitor` is created; `on_settings` dereferences `self.weather_monitor` at :278. It works because `wx.CallAfter` posts to the app's pending queue (verified in `wx.core.CallAfter`) which is drained by `MainLoop`, after `__init__` returns. The welcome dialog is also parented to a frame that has no menu, status bar or size yet and is not shown.
+- **Failure scenario**: First launch from a checkout run outside the repo root (see L7) → welcome dialog → Yes → sound-missing message box → if pending events are dispatched inside that native loop, Settings opens and "Save" crashes with `AttributeError` reported by the unhandled-exception dialog; nothing saved.
+- **Evidence**: `main_window.py:79` `self._check_first_launch()` precedes `:117` `self.weather_monitor = WeatherMonitor(...)`.
+- **Suggested fix direction**: Move `_check_first_launch()` to the end of `__init__` (after `Show`), or construct the model/controller objects before it.
+
+### L5. Settings: the new weather interval is applied to the running monitor before the save is known to succeed
+- **Severity**: Low — only diverges when `save_config` fails; then the running value and the file disagree until restart.
+- **Confidence**: Confirmed
+- **Location(s)**: `src/gui/main_window.py:277-292`
+- **What is wrong**: `self.weather_monitor.set_interval(...)` at :278 runs before `save_config(config)` at :279; on failure the user is told "Failed to save settings" but the interval has already changed for the session, and the message "Settings saved successfully. The new settings will be used for future operations" is slightly misleading in the success case too (the interval takes effect immediately, the codes only on the next Connect, `auto_tune_com1` on the next message).
+- **Suggested fix direction**: Apply runtime changes inside the `if save_config(config):` branch; word the confirmation accordingly.
+
+### L6. `load_config`/`save_config` log the whole config — both logon codes included — at DEBUG, and the config is re-read from disk on every message
+- **Severity**: Low — no leak at the default INFO level, but it undermines the `redact()` policy the rest of the code follows, and one flip of the log level (there is no setting for it, so a developer edit) writes credentials into the rotating log.
+- **Confidence**: Confirmed
+- **Location(s)**: `src/config.py:52, 85`; `src/gui/main_window.py:1010` (also `:98, :242`, `connect_dialog.py:27`, `pdc_dialog.py:27`); `src/model/connection_manager.py:61-73` (the redaction policy)
+- **What is wrong**: `logger.debug(f"Loaded config: {config}")` / `f"Saved config: {config}"` include `sayintentions_logon_code` and `hoppie_logon_code`. `_on_message_received` calls `load_config()` (disk read + that debug line) for every message from the current station just to read one boolean.
+- **Suggested fix direction**: Log only the key names or a redacted copy; cache `auto_tune_com1` on the window and refresh it when Settings is saved.
+
+### L7. `resource_path()` resolves relative to the current working directory in development mode
+- **Severity**: Low — only affects source runs started from another directory; produces a startup warning box every time and no notification sound.
+- **Confidence**: Confirmed by reading
+- **Location(s)**: `src/gui/main_window.py:56-64, 82-89`; `README.md:43-46`
+- **What is wrong**: `base_path = os.path.abspath(".")` when not frozen; `python C:\path\to\sim-cpdlc\app.py` from elsewhere (shortcut, IDE run configuration, scheduler) cannot find `assets/message.wav`.
+- **Suggested fix direction**: Use the directory of `app.py` (`os.path.dirname(os.path.abspath(sys.argv[0]))` or a module-relative path) as the development base.
+
+### L8. Stopping a subscription from the "Automatic weather updates" dialog gives no confirmation message, unlike the other two stop paths
+- **Severity**: Low — feedback inconsistency that lands hardest on screen-reader users.
+- **Confidence**: Confirmed
+- **Location(s)**: `src/gui/dialogs/weather_subscriptions_dialog.py:131-157`; compare `src/gui/main_window.py:728-732, 886-891`
+- **What is wrong**: `on_stop`/`on_stop_all` call `unsubscribe()`/`clear()` and refresh the list; the context-menu and request-dialog paths add a "Stopped automatic updates for METAR EGLL" SYSTEM message and set the status bar. From the dialog, the only evidence is that the list entry vanished (or the dialog is left open with an empty list after Stop all).
+- **Suggested fix direction**: Route the dialog's stop actions through the same `MainWindow._on_toggle_weather_updates`-style helper, or pass a callback that adds the SYSTEM message.
+
+### L9. Frequency parser requires a unit name between CONTACT/MONITOR and the frequency, and its DOTALL comment is wrong
+- **Severity**: Low — auto-tune silently does nothing for a unit-less instruction; the message itself is still shown.
+- **Confidence**: Plausible (whether either network emits "CONTACT 121.500" without a unit name was not verified; the regex behaviour was)
+- **Location(s)**: `src/utils/frequency_parser.py:7-14`
+- **What is wrong**: `.+?\s+` demands at least one token before the frequency, so `CONTACT 121.500` and `CONTACT 121.500 MHZ` return None (verified), while every realistic text with a unit name (`CONTACT MAASTRICHT 132.850 MHZ`, `MONITOR UNICOM 122.8`, `CONTACT LONDON CONTROL 127.425 WHEN READY`, 8.33 kHz `132.855`, `CLIMB TO FL350 CONTACT …`, two-frequency texts → first) parses correctly. The comment "DOTALL so \s+ matches newlines" is inaccurate: `\s` always matches newlines; DOTALL is what lets `.+?` span them. There is no unit test for this module.
+- **Suggested fix direction**: Make the unit-name group optional (`(?:.+?\s+)?`) and add a `tests/test_frequency_parser.py` with the cases above.
+
+### L10. Message list columns are auto-sized once, before any rows exist, and never resized
+- **Severity**: Low — sighted users may see clipped Sender/Message cells; screen readers still get the full text.
+- **Confidence**: Plausible (wxMSW behaviour of `LIST_AUTOSIZE` with zero rows not verified in a live window)
+- **Location(s)**: `src/gui/message_view.py:56-62, 77-89`
+- **What is wrong**: `InsertColumn(…, width=-1)` (`wx.LIST_AUTOSIZE`, verified value) is evaluated when the list is empty; `add_message` never calls `SetColumnWidth`, so the widths do not follow the content.
+- **Suggested fix direction**: Use `LIST_AUTOSIZE_USEHEADER` for Sender, give Message a proportional width in an `EVT_SIZE` handler, or call `SetColumnWidth(1, wx.LIST_AUTOSIZE)` after inserting.
+
+### L11. `@@` → `N/A` substitution is not space-padded, gluing words together
+- **Severity**: Low — affects display/readability only, and only when `@@` occurs in CPDLC text.
+- **Confidence**: Plausible (frequency of `@@` in real uplinks unknown; behaviour verified)
+- **Location(s)**: `src/utils/message_formatting.py:25-30, 39-41`
+- **What is wrong**: `"CLIMB TO@FL350@@REPORT LEVEL"` renders as `CLIMB TO FL350N/AREPORT LEVEL` in the list and `FL350N/AREPORT LEVEL` in the detail pane; NVDA reads "FL350N slash AREPORT".
+- **Suggested fix direction**: Replace with `" N/A "` and collapse whitespace, or drop the substitution if it no longer corresponds to observed traffic.
+
+### L12. `on_disconnect` blocks the GUI with `wx.MilliSleep(500)` for nothing and bumps polling just before stopping it; comment is misleading
+- **Severity**: Low — half a second of frozen UI on every logged-on disconnect; no functional effect.
+- **Confidence**: Confirmed
+- **Location(s)**: `src/gui/main_window.py:383-386`
+- **What is wrong**: `send_cpdlc` is synchronous (`requests.post` has returned before `logoff()` returns), so "Small delay to allow the message to be sent" describes nothing real; `set_active_polling()` immediately followed by `polling_controller.stop()` is a no-op pair.
+- **Suggested fix direction**: Delete both lines and the comment.
+
+### L13. Update dialog does not say that "Yes" closes the application
+- **Severity**: Low — surprising, and mid-flight it triggers the exit path (the exit confirmation appears only if connected).
+- **Confidence**: Confirmed
+- **Location(s)**: `src/utils/update_checker.py:134-150`
+- **What is wrong**: The prompt asks "Would you like to download the update now?"; on Yes it opens the browser and `wx.CallAfter(self.parent.Close)`. When not connected, the app closes with no further question.
+- **Suggested fix direction**: Say so in the prompt ("…and close Sim-CPDLC?") or do not close; let the user finish.
+
+### L14. Console log handler is dead weight in the windowed build (`sys.stderr` is None), while the SimBrief module's logger never reaches the file at all
+- **Severity**: Low — diagnostics only, but it means the one place that knows *why* a SimBrief fetch failed writes nowhere.
+- **Confidence**: Confirmed for the logger name (no handler on `src.utils.simbrief`, `propagate` to a root with no handlers → `logging.lastResort`, WARNING+ to stderr only); Plausible for `sys.stderr is None` under PyInstaller `console=False` (PyInstaller not installed in the review venv)
+- **Location(s)**: `src/utils/simbrief.py:8, 46-60`, `src/logging_setup.py:12-27`, `src/gui/dialogs/connect_dialog.py:77-83`, `pdc_dialog.py:93-99`, `app.spec:59`
+- **What is wrong**: `simbrief.py` is the only module using `logging.getLogger(__name__)`; `setup_logging` configures only "Sim-CPDLC". `fetch_ofp` swallows every exception and returns None, logging the reason (timeout, HTTP status, JSON error) to the orphan logger. The dialogs then log the uninformative "Failed to fetch SimBrief OFP data". In the frozen build `StreamHandler()` wraps `sys.stderr`, which is None for a windowed process, so every record also takes the `handleError` path silently.
+- **Suggested fix direction**: `logging.getLogger("Sim-CPDLC")` in `simbrief.py` (or make it a child `"Sim-CPDLC.simbrief"`), and only add the console handler when `sys.stderr` is not None.
+
+### L15. Personal SimBrief data and a live-API script are committed under `src/`
+- **Severity**: Low — repository hygiene; the data is the maintainer's own but includes a real name, SimBrief user id and a complete OFP (164 KB), and the script overwrites it on run.
+- **Confidence**: Confirmed
+- **Location(s)**: `src/utils/latest_simbrief_ofp.json` (since the initial commit), `src/utils/test_simbrief.py:20, 42-47`, `pytest.ini:2-4`, `.gitignore`
+- **What is wrong**: `test_simbrief.py` hard-codes user id `189007` and writes `latest_simbrief_ofp.json` next to itself; the JSON contains `crew.cpt = "ROBIN KIPP"`, `params.user_id`, `api_params.cpt`, full route/fuel data. `pytest.ini` exists partly to keep pytest from collecting the script. Neither file is used by the application.
+- **Suggested fix direction**: Delete both (or move the script to `tools/` reading the id from an environment variable) and add `src/utils/latest_simbrief_ofp.json` to `.gitignore` if the script stays.
+
+### L16. Packaging/requirements inconsistencies
+- **Severity**: Low — none breaks the current release, but each is a latent surprise.
+- **Confidence**: Confirmed
+- **Location(s)**: `requirements.txt:2, 7`, `app.spec:11-18, 35`, `.gitignore:1-6`, `.github/workflows/build-and-release.yml`, `.github/dependabot.yml`
+- **What is wrong**:
+  - `pyinstaller==6.20.0` is in the *runtime* requirements, so every source user installs a build tool; conversely `pytest` is correctly split out.
+  - `SimConnect>=0.4.26` is the only unpinned dependency (PyPI's latest is 0.4.26, verified), and it is absent from the review venv that otherwise satisfied `requirements.txt` — a build machine without it produces an installer in which auto-tune silently never works (`app.spec` bundles `SimConnect.dll` only `if os.path.isfile(_sc_dll)`, and PyInstaller only warns about a missing hidden import).
+  - `.gitignore` lacks `installer/` (Inno's `OutputDir`), `.pytest_cache/`.
+  - The release workflow does not run the test suite before building; `fetch-depth: 0` is unused; dependabot covers pip but not the GitHub Actions used.
+- **Suggested fix direction**: Split `requirements-build.txt`, pin `SimConnect==0.4.26`, fail the build if the DLL is not found, extend `.gitignore`, add a `needs: test` job to the release workflow.
+
+### L17. README describes behaviour the code does not have
+- **Severity**: Low — documentation drift.
+- **Confidence**: Confirmed
+- **Location(s)**: `README.md:20, 84-91, 109-110, 149-158`; `tests/README.md:17-30`; `app.py:3`; `src/gui/dialogs/about_dialog.py:18`
+- **What is wrong**:
+  - "Requesting Altitude Changes … Select: Desired altitude, Climb or descent" — the dialog has no climb/descent choice; the message is `REQUEST FL350`.
+  - "The report is added to the message list and the notification sound plays" — `_add_weather_message` defaults to `play_sound=False` for a requested report, and `test_a_report_the_pilot_asked_for_arrives_quietly` pins that.
+  - "Automatic Reconnection: Handles connection issues gracefully" — one attempt after three failures, then polling stops and the user must reconnect by hand (see M1).
+  - The tests table omits `test_config.py` and `test_weather_parsing.py`.
+  - `app.py` docstring: "A simple CPDLC client for SayIntentions.ai" (Hoppie is the other half).
+- **Suggested fix direction**: Align the README with the dialogs and the sound policy; regenerate the tests table.
+
+### L18. Protocol-state handling is keyed on duck-typed text, so a TELEX whose body is "LOGON ACCEPTED", "HANDOVER XXXX" or "LOGOFF" can change the session
+- **Severity**: Low — requires a station to send those exact words as free text; consequence is a wrong logon state.
+- **Confidence**: Plausible
+- **Location(s)**: `src/gui/main_window.py:926-928, 946-1007`
+- **What is wrong**: The branch is gated on `hasattr(message, "get_packet_content") and hasattr(message, "get_from_name")`, which every `HoppieMessage` (telex, progress, ADS-C) satisfies; only `get_mrn` is conditional. A `TelexMessage("EDDF", …, "LOGON ACCEPTED")` therefore calls `handle_logon_accepted("EDDF", None)` and, with no logon pending, is accepted.
+- **Suggested fix direction**: Gate the LOGON ACCEPTED / HANDOVER / LOGOFF handling on `isinstance(message, CpdlcMessage)` (already imported and currently unused); keep the auto-tune branch for telex if desired.
+
+### L19. Logging on to a second station while logged on neither logs off the first nor updates state until acceptance, and restarts the MIN counter mid-dialogue
+- **Severity**: Low — unusual pilot action; the status bar then says "Pending logon to B" while `is_logged_on()` still returns A.
+- **Confidence**: Confirmed by reading
+- **Location(s)**: `src/model/cpdlc_session.py:62-106` (`:85` resets `cpdlc_min_counter = 1`), `src/gui/main_window.py:404-449`
+- **What is wrong**: `logon()` does not require `current_station` to be empty; it resets the MIN counter to 1 while the dialogue with the old station continues (an acknowledgement sent to the old station in the meantime would reuse MINs it has already seen), and if the new station never answers the app stays logged on to the old one under a "Pending logon" status. `pending_logon_*` is never expired.
+- **Suggested fix direction**: Either send LOGOFF to the current station first (as the HANDOVER path effectively does) or ask for confirmation; clear `pending_logon_*` on user logoff/disconnect.
+
+---
+
+## Info (code quality; no direct user-visible effect)
+
+### I1. Unused imports
+- **Confidence**: Confirmed (AST scan)
+- `src/gui/main_window.py:9-14`: `CpdlcMessage`, `CpdlcResponseRequirement as RR`, `HoppieMessage` (the `hasattr` checks in `_on_message_received` are what these would replace).
+- `src/model/cpdlc_session.py:3-4`: `logging`, `Callable`.
+- `src/controller/polling_controller.py:5`: `logging`.
+
+### I2. Dead code and dead parameters
+- `MessageManager.get_weather_key` (`src/model/message_manager.py:164-174`) has no caller.
+- `PollingController.default_poll_interval` (`polling_controller.py:30, 41-42, 52`) is stored and never read; `DEFAULT_POLL_INTERVAL` is threaded from `config.py` through `main_window.py:110` for nothing, and the docstring "used only when a jitter range is not available" describes a path that cannot occur (`poll_interval_range` always falls back to the config band).
+- `ConnectionManager.message_callback` (`connection_manager.py:94-116`) is never used.
+- `poll_status` from `cnx.poll()` is discarded (`connection_manager.py:286-295`, `polling_controller.py:149`).
+- `extract_atis_letter(text, icao=None)` keeps an ignored parameter (`weather_parsing.py:141-176`) — documented as "call-site compatibility", but all call sites are in-repo.
+- `self.menu_item_logoff` (`main_window.py:185-188`) is an attribute only so it can be bound; the comment "Always enable both logon and logoff menu items" describes code that no longer exists.
+- `is_running()` docstring aside, `PollingController.parent_window` is only read by `_set_status`, which duck-types `SetStatusText` (`:202`).
+
+### I3. Duplication the PR-24 spec left open, still open
+- Seven handlers hand-roll the "Not Connected" message box (`main_window.py:407-413, 495-501, 537-543, 574-580, 613-619, 663-669, 800-806`) though `_require_connection` (`:692-709`) exists and is used once; five hand-roll "Not Logged On" (`:503-509, 545-551, 582-588, 621-627` plus `on_logoff`).
+- `CpdlcSession.send_altitude_change_request`, `send_direct_request`, `send_speed_request`, `send_when_can_we_expect` (`cpdlc_session.py:154-197, 264-368`) differ only in the message text; the guard/try/increment/return block is repeated four times.
+- `_on_message_received` repeats the `hasattr`/`extract_message_content`/`@`-normalisation block twice (`main_window.py:926-934` and `:946-953`).
+- `_check_first_launch` re-imports `os`, `load_config`, `save_config` inside the function (`main_window.py:1127-1128`); `os` is already a module import and the two functions are unused there. (Note this local import would also bypass the `mw.load_config` monkeypatch the tests rely on, were the method not stubbed entirely.)
+- `SpeedRequestDialog.on_text_change` identical branches (see L3).
+
+### I4. Indirection with no purpose
+- `CpdlcSession.send_logoff_message` (`cpdlc_session.py:143-152`) is an alias "kept for backward compatibility" in an application with no external callers; both call sites (`main_window.py:380, 1085`) could call `logoff()`.
+- `MainWindow.get_current_station` (`main_window.py:648-658`) wraps `cpdlc_session.get_current_station()` behind an `is_logged_on()` check that is by definition equivalent (`is_logged_on` is `bool(current_station)`); its only consumer is `TelexDialog`, which reaches into `parent.get_current_station()` (`telex_dialog.py:27-28`), coupling the dialog to the MainWindow API instead of taking the value as a constructor argument.
+- `resource_path` is an instance method that never uses `self` (`main_window.py:56-64`).
+
+### I5. `hasattr` duck typing where `isinstance` is available
+- `main_window.py:926-928, 946-948, 958`; `polling_controller.py:202`. `HoppieMessage`/`CpdlcMessage` are imported in `main_window.py` for exactly this and unused (see L18 for the one behavioural consequence).
+
+### I6. Inconsistent logger acquisition
+- A logger is injected into models/controller/window; `ConnectDialog`, `PDCDialog`, `config.py`, `simconnect_manager.py`, `update_checker.py` fetch `logging.getLogger("Sim-CPDLC")`; `simbrief.py` uses `__name__` (the one that actually misbehaves, L14).
+
+### I7. Accessibility conventions are applied unevenly
+- Mnemonics (`&`) and `SetName` are used in `WeatherDialog` and `WeatherSubscriptionsDialog` and on the Settings spin control only; `Connect`, `Logon`, `PDC`, `Altitude`, `Direct`, `Speed`, `When can we`, `Telex`, `Settings` text fields rely on the preceding `StaticText` for their accessible name (works with NVDA on MSW, but is the implicit form).
+- `ConnectDialog` creates `wx.RadioBox(label="")` with a separate "Select Network:" static text (`connect_dialog.py:35-45`), so the group itself has no accessible name.
+- Helper texts use a hard-coded grey `wx.Colour(100, 100, 100)` (`altitude:40`, `direct:31`, `speed:43`, `when_can_we:50`), low contrast and unaffected by high-contrast themes.
+- Accelerators reuse OS conventions: `CTRL+S` (Speed change; Save), `CTRL+W` (When can we; Close), `CTRL+O` (Logoff; Open) — `main_window.py:186-199`. Harmless (a dialog opens) but surprising.
+- Menu mnemonic uniqueness is tested (`tests/test_main_window.py:156-174`), which is good; the same check is not applied inside dialogs.
+
+### I8. Test coverage gaps in this lens
+- No tests for `src/utils/frequency_parser.py` or `extract_message_content`; `tests/README.md` table omits two existing files.
+
+### I9. Smaller code-quality notes
+- `WeatherMonitor.stop()` sets `_shutting_down = True` (`weather_monitor.py:120-125`); the flag name suggests process exit but it also gates plain disconnects and `check_now()` — fine functionally, misleading to read.
+- `WeatherMonitor._post_result`/`_post_cycle_finished` read `self._parent.IsBeingDeleted()` from the worker thread (`:302-313`); a flag read, benign, but it is wx state touched off the GUI thread.
+- `app.py:103-105` calls `frame.on_exit(None)` after `MainLoop()` has returned on `KeyboardInterrupt`, when the frame may already be destroyed (`RuntimeError: wrapped C/C++ object … has been deleted`); unreachable in the windowed build.
+- Dialog handlers have no `try/finally` (or `with` context manager) around `ShowModal … Destroy`, so a non-`HoppieError` exception between them (e.g. the `FileNotFoundError` that `test_a_local_os_error_is_not_disguised_as_a_network_failure` deliberately lets escape) leaks the dialog.
+- Type hints: `add_custom_message(self, text: str, sender: str = None)` (`message_manager.py:126`) should be `Optional[str]`; `connection_manager.py` is untyped while `cpdlc_session.py` is fully typed.
+- `about_dialog.py:19` copyright year is fixed at 2025.
+
+---
+
+## Things I checked that are fine
+
+- **`global` after use in `simconnect_manager.set_com1_standby_mhz` (:76-93)**: valid Python — the name is not referenced earlier *in that function*, and a `global` statement applies to the whole function body; the module compiles (verified). Availability caching/reset logic and the two-attempt retry are coherent; `_warned_unavailable` prevents log spam.
+- **First-launch flow**: on the normal path `wx.CallAfter(self.on_settings, None)` runs from `MainLoop`, after `__init__` has created `weather_monitor`; `save_config` creates the file before the settings dialog reads it; `on_settings` destroys its dialog on both branches (see L4 for the ordering fragility only).
+- **Settings while connected**: `set_interval` stops/restarts the timer correctly; `weather_interval_minutes()` clamps type and range on every read (bool excluded); the SpinCtrl is bounded 1–60 and `SettingsDialog` passes an already-clamped initial value.
+- **Exit paths**: `on_close` vetoes correctly when the user declines while connected; sends LOGOFF, stops polling, shuts the weather monitor down (timer destroyed), disconnects SimConnect, then `Skip()`s; `on_exit` → `Close()` → same path; the update checker's `Close` goes through the same confirmation when connected; background threads guard `IsBeingDeleted()` before `CallAfter`.
+- **PollingController**: one-shot rescheduling in `finally`, `set_active_polling` only pulls a poll forward, reconnection-failure branch stops deliberately and `_schedule_next` respects `_stopped`; `should_increase_polling_rate` shares `CPDLC_RESPONSES` with `MessageManager`.
+- **Connect → logon → handover → LOGOFF → logoff → disconnect (happy path)**: status bar, menu label, session station and weather monitor stay consistent; `LOGON ACCEPTED` validation against the pending station/MRN is right and unsolicited acceptances still work; HANDOVER regex operates on `@`-normalised text.
+- **Message encodings**: `"sender: text"` is split on the *first* `": "`, so texts containing `": "` round-trip whenever the sender is non-empty; an empty sender is only possible with an empty callsign, which every caller prevents by requiring a connection (verified `MessageManager` behaviour for `("FUEL: 5000","DLH123")`, SYSTEM messages containing `": "`, and the theoretical empty-sender case). `WeatherReport` rows show label/`ICAO: text`, detail shows the `@`-split report; `add_message` drops nothing reachable.
+- **Message types from `poll()`**: `TelexMessage`, `CpdlcMessage`, `ProgressMessage` and the ADS-C classes are all `HoppieMessage` subclasses with `get_from_name`/`get_packet_content`, so all display; only `CpdlcMessage` is answerable (`get_cpdlc_addressing`/`needs_acknowledgement` use `isinstance`); the library drops unparseable items with a warning rather than raising.
+- **MessageView**: `LC_SINGLE_SEL`, `EVT_CONTEXT_MENU` (keyboard-reachable), popup handlers bound and unbound per menu (no accumulation), `SetItemData`/`GetItemData` with small ints, weather menu passes the on-screen text to seed change detection.
+- **`extract_message_content` regex**: strips both `/data2/MIN/MRN/RR/` and `/data2/MIN//RR/` for every RR code the library emits (WU, AN, R, NE, N, Y); leaves non-CPDLC text untouched; handles `None`/`""`.
+- **Frequency parser on realistic texts**: `CONTACT MAASTRICHT 132.850 MHZ`, `MONITOR UNICOM 122.8`, `CONTACT LONDON CONTROL 127.425 WHEN READY`, 8.33 kHz `132.855`, `CLIMB TO FL350 CONTACT …`, `… ON 128.250`, two frequencies (first wins), multi-line, HF (`8879`, `5.598` rejected), out-of-band `117.950`/`136.995` rejected, squawks not mistaken; the `@` separator is normalised by the caller before parsing (verified `CONTACT MAASTRICHT@132.850` → None only when unnormalised).
+- **ATIS letter / signature**: D-ATIS designator, chained markers, NATO words, fallback with time group stripped — all behave as the tests claim; `format_report_text/line` remove `@`.
+- **config.py**: atomic write via `mkstemp` + `os.replace`, tmp file removed on failure; `PermissionError` is caught by `except IOError` (alias of `OSError`); missing keys merged; import-time directory creation is a side effect but idempotent and needed by both config and logging.
+- **Library limits surface**: 220-char/ASCII telex limits, station-name regex, invalid CPDLC characters all become `HoppieError` and reach an error dialog (with logon codes redacted).
+- **Dialog `Destroy()`**: reached on every normal return path in every handler, including the early-return branch in `on_logon`.
+- **WeatherDialog**: checkbox mirrors live subscription state until the user touches it; `on_weather_request` unsubscribes on an unchecked box regardless of fetch outcome and subscribes only after a successful fetch; ATIS is the deliberate default.
+- **Packaging paths**: `app.spec` `datas=('assets/','assets')` matches `resource_path` under `_MEIPASS` in onedir mode; `sim-cpdlc.iss` copies `dist\Sim-CPDLC\_internal\*` (PyInstaller 6 layout); `OutputBaseFilename` matches the workflow's upload path; `update_version.py` regexes match the three files; tag `v*.*.*` → `${GITHUB_REF#refs/tags/v}` is correct; `version.parse(tag.lstrip("v"))` handles the `v` prefix.
+- **The accepted WON'T FIX** (unbounded message log) is not reported.

--- a/docs/audit/lens/2026-09-03-network-protocol.md
+++ b/docs/audit/lens/2026-09-03-network-protocol.md
@@ -1,0 +1,234 @@
+# Sim-CPDLC — network / protocol / credential audit
+
+Scope: `app.py`, everything under `src/`, the tests (read for intent), and all of `hoppie_connector` 0.2.1 (`__init__.py`, `API.py`, `Messages.py`, `Responses.py`, `Utilities.py`, `CPDLC.py`, `ADSC.py`). Read-only. Mechanisms marked *Confirmed* were either traced end-to-end in the code or reproduced with the venv interpreter using in-process fakes for `requests.get`/`post` (no network traffic).
+
+Key library facts the findings rest on (all verified in source):
+
+- `hoppie_connector/API.py:39,44` calls `requests.get(...)` / `requests.post(...)` as **module attributes** after `import requests`. The app's `install_request_timeout()` therefore does take effect — reproduced: the library's GET and POST both arrived at the underlying function with `timeout=15`.
+- `API.py:46-47` raises the **builtin** `ConnectionError` for a non-2xx status; `API.py:50` decodes the body with `.decode('ascii')` (a `UnicodeDecodeError`, subclass of `ValueError`, for any non-ASCII byte); the response parsers raise bare `ValueError`; `_connect` raises `TypeError` or `HoppieError(reason)` for `error {...}`.
+- `__init__.py:66-85` `poll()` parses each `{FROM type {packet}}` item and, on `ValueError`, calls `warnings.warn(..., HoppieWarning)` and **drops the item**. Nothing is raised.
+- `Messages.py:602,613,639-641` `CpdlcMessage` accepts only `[A-Z0-9._@ ]+` as message text, so a CPDLC packet with `-`, `,`, `:`, `/`, `(`, `)`, lowercase letters or an empty text is unparseable.
+- `CpdlcMessage` exposes `get_min()`, `get_mrn()`, `get_rr()` (a `CpdlcResponseRequirement` StrEnum: WU, AN, R, NE, N, Y), `get_from_name()`, and `get_message()` (the bare element text); `get_packet_content()` re-serialises `/data2/{min}/{mrn or ''}/{rr}/{text}`.
+- `Utilities.py:4` validates every FROM/TO station as `^[A-Z0-9]{3,8}$`; `TelexMessage` enforces ≤220 chars and ASCII.
+
+---
+
+## Findings
+
+### 1. Uplinks the library cannot parse are dropped with no trace, after the server has already marked them delivered
+
+- **Severity**: High — an ATC instruction the controller's client shows as *delivered* never reaches the pilot, and nothing in the log or UI says so.
+- **Confidence**: Confirmed (mechanism reproduced); how often real stations send such text is Plausible rather than measured.
+- **Location(s)**: `hoppie_connector/__init__.py:77-85`, `hoppie_connector/Messages.py:602-623,639-641`; `src/model/connection_manager.py:284-308`; `src/controller/polling_controller.py:149-176`; `app.spec:59` (`console=False`).
+- **What is wrong**: `HoppieConnector.poll()` swallows every per-message `ValueError` into a Python `warnings.warn(HoppieWarning)`. The application never captures warnings (`logging.captureWarnings` is not enabled, there is no `catch_warnings` around `cnx.poll()`), and in the packaged build `sys.stderr` is `None`, where `warnings._showwarnmsg_impl` explicitly returns without output. `ConnectionManager.poll()` sees a clean `([], delay)`; no counter moves, no log line is written, no UI element changes. Because Hoppie's `poll` marks messages as relayed when it serves them, the message is gone for good.
+- **Failure scenario**: Controller sends `CLIMB TO FL350 - EXPEDITE`, `FREE TEXT: CALL ME ON 121.5`, `CONTACT LANGEN 127,825`, a message containing `/`, or (from a less strict client) lowercase text. Reproduced with a poll body of five items: the app received only the one plain item; four `HoppieWarning`s were emitted and nothing was logged by the app. Pilot sees nothing; controller sees "delivered", waits for WILCO, then escalates by voice or assumes non-compliance.
+- **Evidence**:
+  ```python
+  # hoppie_connector/__init__.py
+  80:        for d in response.get_data():
+  81:            try:
+  82:                result.append(p.parse(d))
+  83:            except ValueError as e:
+  84:                warnings.warn(f"Unable to parse {d}: {e}", HoppieWarning)
+  # hoppie_connector/Messages.py
+  602:    _MSG_CHARS: re.Pattern = r'[A-Z0-9\.\_\@ ]'
+  613:        m = re.match(r'^/' + cls._EXCHG_FORMAT_PREFIX + r'/(\d+)/(\d*)/(WU|AN|R|NE|N|Y)/(' + cls._MSG_CHARS + r'*)$', packet)
+  ```
+  Reproduction output: `poll returned messages: ['EDGG -> DLH123 [CPDLC] /data2/6//WU/CONTACT LANGEN 127.825']`, warnings: `Invalid CPDLC message format` ×3, `Message contains invalid characters` ×1; `ConnectionManager.poll -> ([], 0.1), connection_failures 0, app log lines []`.
+- **Suggested fix direction**: Wrap `self.cnx.poll` in `warnings.catch_warnings(record=True)` (filter `HoppieWarning`), log each dropped item at ERROR with its `from` and raw packet, and inject a SYSTEM/list entry such as "Unreadable message from EDGG: <raw packet>" with the notification sound so the pilot can ask by voice. Longer term consider parsing `cpdlc` items yourself with a permissive regex (the app already has `extract_message_content`), since the library's character class is stricter than what Hoppie's ATC clients emit.
+
+### 2. CPDLC session state outlives the network connection
+
+- **Severity**: Medium — after a lost or failed-logoff disconnect the app can report and act on a logon that no longer exists, sending requests and a later LOGOFF to a stale station, under a possibly different callsign.
+- **Confidence**: Confirmed.
+- **Location(s)**: `src/gui/main_window.py:349-402` (`on_disconnect`), `316-347` (`on_connect`); `src/controller/polling_controller.py:182-196`; `src/model/cpdlc_session.py:108-141` (`logoff` leaves `current_station` set on failure), `24-28` (state fields).
+- **What is wrong**: `ConnectionManager.disconnect()` clears its own fields, but nothing resets `CpdlcSession.current_station`, `pending_logon_min/station` or `cpdlc_min_counter`. `on_disconnect` only clears `current_station` indirectly by *successfully sending* LOGOFF; if that send fails (which is likely exactly when the user is disconnecting because the link is dead) `logoff()` returns `(False, err)` and leaves the station set. The polling controller's failed-reconnection branch (`attempt_reconnection()` → `cnx = None`, `stop()`) never touches the session either, and does not reset the `&Disconnect` menu label.
+- **Failure scenario**: Logged on to EDGG. Wi-Fi drops; three polls and the ping fail; status reads "Connection lost. Reconnect to continue."; `current_station` is still `EDGG`, `menu_item_connect` still reads "Disconnect". The pilot reconnects (File menu — the "Disconnect" item opens the Connect dialog because `is_connected()` is False), perhaps as a different flight/callsign. Status: "Connected as X." but `is_logged_on()` is True: the Requests menu sends `REQUEST FL350` to EDGG with the old MIN sequence, `on_logoff` offers to log off from EDGG, `get_current_station()` feeds the message view so old EDGG uplinks become answerable again. Same result via user-initiated disconnect when the LOGOFF POST times out.
+- **Evidence**:
+  ```python
+  # main_window.py on_disconnect
+  379:        if self.cpdlc_session.is_logged_on():
+  380:            success, message = self.cpdlc_session.send_logoff_message()
+  ...
+  394:        self.connection_manager.disconnect()     # no cpdlc_session reset anywhere
+  # cpdlc_session.py logoff
+  130:        except HoppieError as exc:
+  134:            return False, str(exc)               # current_station untouched
+  # polling_controller.py
+  191:                    self.logger.error("Reconnection failed")
+  192:                    self._set_status("Connection lost. Reconnect to continue.")
+  196:                    self.stop()                  # session, menu label, weather monitor untouched
+  ```
+- **Suggested fix direction**: Add `CpdlcSession.reset()` (clear station, pending logon, restart MIN) and call it from `on_disconnect` (after the LOGOFF attempt, regardless of its outcome) and from the failed-reconnection path; have the controller notify the window (callback) so it can flip the menu label and add a SYSTEM message on connection loss.
+
+### 3. A manual logon while already logged on sends no LOGOFF, keeps the old station current, and restarts MIN at 1 towards a station that has already seen those MINs
+
+- **Severity**: Medium — leaves one station believing the aircraft is still logged on, and produces duplicate MINs for the same dialogue.
+- **Confidence**: Confirmed.
+- **Location(s)**: `src/gui/main_window.py:404-449` (`on_logon` checks only `is_connected()`); `src/model/cpdlc_session.py:62-106` (`logon` resets `cpdlc_min_counter = 1`, never clears `current_station`).
+- **What is wrong**: `logon()` is callable in any state. It resets the MIN counter to 1 and records a pending logon, but leaves `current_station` as it was. Until the new station accepts, `is_logged_on()` is still True for the *old* station, so every request goes to the old station numbered 2, 3, … — MINs that station already received earlier in the session. If the new station accepts, `current_station` flips with no LOGOFF ever sent to the old one. Re-logging on to the *same* station (a natural thing to try when the pilot suspects they were dropped, since the app gives no indication either way) also restarts MIN at 1 on a dialogue the station may consider still open.
+- **Failure scenario**: Pilot logged on to EDGG at MIN 9 selects Requests > Logon > EDUU by mistake or design. Status: "Pending logon to EDUU." Pilot sends an altitude request: it goes to EDGG as MIN 2 (a MIN EDGG already saw paired with `REQUEST LOGON`'s successor). EDUU accepts: EDGG still shows the aircraft logged on, keeps uplinking; those uplinks appear in the list but offer no responses (sender ≠ current station); controller at EDGG sees no WILCO.
+- **Evidence**:
+  ```python
+  # cpdlc_session.py
+  84:        self.logger.info(f"Attempting to logon to station: {station}")
+  85:        self.cpdlc_min_counter = 1
+  ...
+  103:        # Don't set current_station yet, just increment the counter
+  ```
+- **Suggested fix direction**: In `on_logon`, if `is_logged_on()`, either refuse ("log off first") or send LOGOFF to the current station and clear it before sending the new REQUEST LOGON. Only restart the MIN counter when the previous dialogue was actually closed (LOGOFF sent/received or handover); otherwise keep counting.
+
+### 4. Reconnection is attempted exactly once, then polling stops for good — silently for a screen-reader user
+
+- **Severity**: Medium — a 60-second outage in active mode (or ~3 minutes idle) ends the session permanently, with the only indication being status-bar text; the README promises "Automatic Reconnection".
+- **Confidence**: Confirmed.
+- **Location(s)**: `src/model/connection_manager.py:318-350`; `src/controller/polling_controller.py:182-196, 205-217`; `src/gui/main_window.py` (no SYSTEM message, sound or menu-label change on this path).
+- **What is wrong**: After `MAX_CONNECTION_FAILURES` (3) the controller calls `attempt_reconnection()` *in the same tick*, with no back-off; that pings once, and on failure `cnx` is cleared and the timer is stopped forever. There is no retry schedule, no notification sound, no list entry — unlike connect/disconnect, which both add SYSTEM messages. `_set_status` is the only output, which NVDA users must actively query.
+- **Failure scenario**: Mid-exchange (active mode, 20 s polls) the home router reboots for 70 s. Polls at t=0, 20, 40 fail; the ping at t=40 fails; polling stops. The router is back at t=70 but the client never polls again; the controller's next uplink sits on the server; the pilot, who heard no sound, keeps waiting for a reply.
+- **Evidence**:
+  ```python
+  # polling_controller.py
+  186:                success = self.connection_manager.attempt_reconnection()
+  ...
+  196:                    self.stop()
+  # connection_manager.py
+  347:        except HoppieError as exc:
+  349:            self.cnx = None
+  ```
+- **Suggested fix direction**: Keep polling with exponential back-off (e.g. 20 s → 60 s → 120 s, capped) rather than stopping; treat `attempt_reconnection` as re-verifying rather than terminal; on the transition to "lost" add a SYSTEM message and play the notification sound; update the menu label. Consider the reconnection a state the controller owns instead of a one-off branch.
+
+### 5. A single non-ASCII byte anywhere in a poll body loses every message in that poll and counts as a link failure
+
+- **Severity**: Medium — a batch of valid uplinks is consumed server-side and never shown; three such polls trigger the reconnection logic.
+- **Confidence**: Plausible — mechanism Confirmed by reproduction; whether Hoppie/SayIntentions ever relay non-ASCII bytes to an aircraft is unverified (the library refuses to *send* them, but other clients and SayIntentions' own text are not bound by that).
+- **Location(s)**: `hoppie_connector/API.py:50` (`response.content.decode('ascii')`); `src/model/connection_manager.py:136-143, 296-308`.
+- **What is wrong**: The decode happens on the whole body before any per-message parsing, so one `°`, `–` or umlaut in any telex/ATIS/free text raises `UnicodeDecodeError` (a `ValueError`) for the entire response. `_call` converts it to a protocol `HoppieError`; `poll()` logs "Poll error: 'ascii' codec can't decode…" and increments `connection_failures`. The messages were already served and therefore marked relayed.
+- **Failure scenario**: Reproduced: body `ok {EDGG cpdlc {/data2/5//WU/CLIMB TO FL350}} {EDDF telex {WIND 270°/25KT}}` → `poll()` returned `(None, None)`, `connection_failures` 1, status "Connection problem (1/3) - retrying…", and the CLIMB instruction is gone.
+- **Evidence**: `API.py:50: content = response.content.decode('ascii')`; reproduction log: `ERROR: Poll error: 'ascii' codec can't decode byte 0xb0 in position 67`.
+- **Suggested fix direction**: The app cannot change the decode inside the library, but it can subclass/shadow `HoppieAPI.connect` (the `HoppieConnector._api` attribute) to decode with `errors="replace"` (or `latin-1`) before handing the text to the parser, and at minimum distinguish this error in the log/status from a transport outage so it is not reported as a connection problem.
+
+### 6. `_SERVER_INFO_PATTERN` cannot match an empty envelope, so the "no report" guard is dead and `{server info {}}` is shown as weather
+
+- **Severity**: Low — cosmetic for a manual request, but for a subscription it means the "give up after 5 failures" logic never engages for an airport with nothing to report.
+- **Confidence**: Confirmed (regex behaviour reproduced); that the server answers exactly `ok {server info {}}` is Plausible (it is what the code's own comment assumes).
+- **Location(s)**: `src/model/connection_manager.py:32, 435-442, 470-475`.
+- **What is wrong**: `(.+)` requires at least one character; for `{server info {}}` the match fails, the unwrapping is skipped and the *literal envelope string* is returned. `send_info_request`'s `if not report_text` therefore never fires for the case its comment describes. A bare `ok` (no space) falls to the "Unexpected response: ok" branch, which reads like a fault rather than "no data".
+- **Failure scenario**: Reproduced: body `ok {server info {}}` → `send_info_request` returned `'{server info {}}'`; body `ok` → `HoppieError: Unexpected response: ok`. A pilot subscribing to a mistyped ICAO gets a list entry "ATIS ZZZZ: {server info {}}" and the subscription lives forever (each cycle returns the same text → "no change").
+- **Evidence**: `32: _SERVER_INFO_PATTERN = re.compile(r"^\{server info \{(.+)\}\}$", re.DOTALL)`; `471: if not report_text:`.
+- **Suggested fix direction**: Use `(.*)`; treat `body == "ok"` and an empty inner text as "no report available"; keep the `error {}` branch but strip the braces from the reason.
+
+### 7. Session-control detection does not check the message type: a TELEX reading `LOGON ACCEPTED`, `LOGOFF` or `HANDOVER XXXX` drives CPDLC state
+
+- **Severity**: Low — requires a station (or anyone on the open Hoppie network using that station code as `from`) to send such a telex, but the fix is one `isinstance`.
+- **Confidence**: Confirmed (a `TelexMessage("EDGG", …, "logon accepted")` yields `msg_text == "LOGON ACCEPTED"` after `extract_message_content`, and `get_mrn` is absent so `mrn=None`, which `handle_logon_accepted` accepts).
+- **Location(s)**: `src/gui/main_window.py:926-928, 946-958, 968-1007`.
+- **What is wrong**: The branch is guarded by `hasattr(message, "get_packet_content") and hasattr(message, "get_from_name")`, which every `HoppieMessage` satisfies (telex, progress, ADS-C). Only `get_mrn` is probed optionally.
+- **Failure scenario**: While logged on to EDGG, a telex from `EDGG` (or from any station if no logon is pending) containing exactly `LOGOFF`/`LOGON ACCEPTED` changes `current_station`; a telex `HANDOVER EDUU` from the current station triggers an automatic REQUEST LOGON to EDUU.
+- **Evidence**: `926: if hasattr(message, "get_packet_content") and hasattr(message, "get_from_name"):` … `958: mrn = message.get_mrn() if hasattr(message, "get_mrn") else None`.
+- **Suggested fix direction**: `if isinstance(message, CpdlcMessage):` around the session-state block, and use `message.get_message()` / `get_mrn()` / `get_rr()` directly (see Info item on `extract_message_content`).
+
+### 8. One failed send makes the status bar claim "Connection problem (1/3) - retrying…" on every successful poll until the next successful send
+
+- **Severity**: Low — misleading link status for an indefinite period; nothing is actually retrying.
+- **Confidence**: Confirmed (reproduced: after one timed-out telex and two good polls, `failure_count()==1`, `poll_failed()==True`).
+- **Location(s)**: `src/model/connection_manager.py:310-316`; `src/controller/polling_controller.py:205-217`.
+- **What is wrong**: `poll_failed()` is `max(connection_failures, send_failures) > 0`; only a successful *send* clears `send_failures`, so a transient failure on a telex or WILCO is reported as an ongoing poll problem by `_report_connection_state` on every tick.
+- **Failure scenario**: Pilot's WILCO POST times out once (dialog shown). Every poll afterwards rewrites the status bar to "Connection problem (1/3) - retrying…" although polls succeed; the "Logged on to EDGG." text is gone; a screen-reader user querying the status bar concludes the link is bad.
+- **Evidence**: `312: return max(self.connection_failures, self.send_failures)`; `316: return self.failure_count() > 0`; `207-214`.
+- **Suggested fix direction**: Report poll health from `connection_failures` only; report send failures at the moment they happen (they already raise a dialog) and let `should_attempt_reconnection` keep using the max.
+
+### 9. An exception in the message callback aborts the rest of the poll batch (already consumed server-side)
+
+- **Severity**: Low — mechanism confirmed, trigger requires a bug or wx failure inside `_on_message_received`, which is reasonably robust today.
+- **Confidence**: Confirmed.
+- **Location(s)**: `src/controller/polling_controller.py:159-176`.
+- **What is wrong**: The `raise` inside the per-message loop leaves the loop; messages 2..n of the same poll are never added to the list, never announced, and cannot be re-fetched. `check_polling_timeout()` and the reconnection check are also skipped for that tick.
+- **Failure scenario**: A poll returns three uplinks; the first trips e.g. a wx error in `SetStatusText` during window teardown or a future bug in the handover branch; the two others vanish.
+- **Evidence**: `164-172: try: self.message_callback(message) except Exception: self.logger.exception(...); raise`.
+- **Suggested fix direction**: Log with `logger.exception`, remember the first exception, continue the loop, then re-raise (or report via the global handler) after all messages have been processed.
+
+### 10. Recoverable-looking loop when `attempt_reconnection()` raises anything other than `HoppieError` (the OSError-for-CA-bundle case the code deliberately does not classify)
+
+- **Severity**: Low — mechanism Confirmed, but the trigger (CA bundle path becoming invalid *mid-session*, e.g. `REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE` pointing at a removed file or an AV quarantining `certifi/cacert.pem`) is uncommon; at initial connect the same error surfaces once as an "Unexpected Error" dialog, which is acceptable.
+- **Confidence**: Confirmed (reproduced with `requests.get` raising `OSError("Could not find a suitable TLS CA certificate bundle…")`).
+- **Location(s)**: `src/model/connection_manager.py:19-24, 327-350`; `src/controller/polling_controller.py:182-198`; `app.py:38-51, 73-76`; `requests/adapters.py:302-306` (plain `OSError`), `requests/sessions.py:768-769` (env override).
+- **What is wrong**: `poll()` catches everything, so each OSError poll adds one to `connection_failures`. `attempt_reconnection()` catches only `HoppieError`; the OSError from `ping` escapes, so `self.cnx` keeps the old connector, the counter is not reset, `should_attempt_reconnection()` stays True. The `finally` in `on_poll_timer` reschedules; the escaped exception reaches `OnExceptionInMainLoop` → modal "Unexpected Error" dialog. Because wx timers keep firing inside a modal loop, the next tick repeats: another failed poll, another escaped OSError, another stacked dialog, every 20-75 s.
+- **Failure scenario**: Reproduced state after one attempt: `cnx is old object: True, connection_failures 3, should_attempt_reconnection True`; next `poll()` → failures 4, still True.
+- **Evidence**:
+  ```python
+  339:            self.cnx = self._open(self.callsign, self.logon_code, self.network_type)
+  347:        except HoppieError as exc:   # OSError/others escape with cnx and counters intact
+  ```
+- **Suggested fix direction**: In `attempt_reconnection` (and `connect`) catch `Exception`, log it, set `cnx = None`, return False — keeping the *classification* decision (not counting OSError as a transport failure) but not letting it break the state machine. Also `wx.CallAfter`-coalesce the global error dialog so repeated failures do not stack modals.
+
+  Related packaging note: TLS *verification* failures (corporate MITM, wrong clock) raise `requests.exceptions.SSLError`, which is a `RequestException` and is handled/redacted correctly; reconnection cannot fix them, so the user ends at "Connection lost" with the real reason only in the log. PyInstaller normally bundles `certifi/cacert.pem` (the venv here has no PyInstaller installed, so its hook could not be inspected directly), so the OSError path is not expected in a healthy install.
+
+### 11. Latent credential leaks: unredacted URL survives in the exception chain; DEBUG logging writes both logon codes to the log file
+
+- **Severity**: Low — no currently reachable path was found that prints either, but both are one line away from doing so.
+- **Confidence**: Confirmed (reproduced: `str(HoppieError)` contains no secret, `traceback.format_exception(HoppieError)` does, via `__cause__`).
+- **Location(s)**: `src/model/connection_manager.py:137, 141-143, 181` (`raise … from exc`); `app.py:39-42` (`traceback.format_exception` of anything unhandled); `src/controller/polling_controller.py:171` (`logger.exception`); `src/config.py:52, 85` (`logger.debug(f"Loaded config: {config}")` / `Saved config`); `src/logging_setup.py:13` (level INFO today).
+- **What is wrong**: `redact()` scrubs the *message* but the original `requests` exception — whose text embeds `…connect.html?logon=<code>&from=…` — is kept as `__cause__`. Python's traceback formatting (used by the unhandled-exception handler and `logger.exception`) prints chained causes in full. Today every `HoppieError` is caught before it can reach either, so this is dormant. Separately, the whole config dict, including `sayintentions_logon_code` and `hoppie_logon_code`, is formatted into DEBUG lines; the logger is fixed at INFO, so they are not emitted — but that is exactly the level a user would be asked to raise for troubleshooting, and the resulting log would be shared.
+- **Failure scenario**: A future `logger.exception(...)` around a send, or a HoppieError escaping a new handler, writes `logon=<code>` into `sim-cpdlc.log`; or a debug build is shipped and the user emails the log.
+- **Evidence**: reproduction: `traceback.format_exception(HoppieError) contains SECRET? True`; `config.py:52: logger.debug(f"Loaded config: {config}")`.
+- **Suggested fix direction**: Raise the redacted `HoppieError` with `from None` (or attach a redacted copy of the cause); redact the config dict before logging (or log only non-secret keys); optionally run `redact()` inside the global exception handler's log line.
+
+### 12. Logon lifecycle has no negative paths: exact-match acceptance, no rejection handling, no pending timeout, no station-online check
+
+- **Severity**: Low — each is a robustness gap rather than a demonstrated fault; together they are the main ways the pilot and the station end up disagreeing about the logon.
+- **Confidence**: Plausible.
+- **Location(s)**: `src/gui/main_window.py:956, 968-1007`; `src/model/cpdlc_session.py:396-451`.
+- **What is wrong**:
+  - Acceptance requires `msg_text == "LOGON ACCEPTED"` exactly (after `@`→space normalisation). A station appending anything (e.g. `LOGON ACCEPTED. WELCOME`) leaves the app at "Pending logon" while the station considers the aircraft connected; every subsequent uplink from it is then unanswerable (sender ≠ current station) and a later `HANDOVER` from it is ignored by the `elif sender == current_station` guard.
+  - There is no handling of a rejection (`LOGON REJECTED`, `UNABLE` with MRN 1, or an `error {}`), so `pending_logon_station` persists and the status bar says "Pending logon to X." indefinitely.
+  - A pending logon never times out; a LOGON ACCEPTED from another station while one is pending is rejected by design (`cpdlc_session.py:418-423`), which is right for stale acceptances but also blocks a forwarded/redirected logon.
+  - The station's presence is never checked: if the controller disconnects without sending LOGOFF (common on VATSIM), the app shows "Logged on to X" for the rest of the flight and keeps sending requests into a queue nobody reads. `HoppieConnector.ping(stations)` exists and could be used occasionally (not per poll) to detect this.
+- **Suggested fix direction**: Match `startswith("LOGON ACCEPTED")`; treat `LOGON REJECTED`/an `UNABLE` carrying MRN==pending MIN as clearing the pending state with a status message; expire a pending logon after a few minutes; ping the current station every few minutes (well within Hoppie's rules) and flag it when it goes offline.
+
+### 13. SimBrief fetch: blocks the GUI thread before the dialog appears, and its diagnostics never reach the log file in the packaged build
+
+- **Severity**: Low.
+- **Confidence**: Confirmed.
+- **Location(s)**: `src/utils/simbrief.py:8, 26-60`; `src/gui/dialogs/connect_dialog.py:57-90`; `src/gui/dialogs/pdc_dialog.py:48-106`; `src/logging_setup.py:12-27`.
+- **What is wrong**: `get_latest_ofp()` runs synchronously inside the dialog constructors with `timeout=10` (connect + read, so up to ~20 s) — the Connect/PDC dialog simply does not appear while SimBrief is slow, with no feedback. Every failure (timeout, DNS, HTTP 400 for an unknown user id — SimBrief returns a JSON body explaining it — non-JSON body) is collapsed into `None`, and the detail is logged to `logging.getLogger("src.utils.simbrief")`, which has no handler: it propagates to the root logger, which only has Python's last-resort stderr handler, and stderr is `None` in the frozen build. The dialogs then log only "Failed to fetch SimBrief OFP data". The `except Exception` branches in the dialogs are effectively unreachable because `fetch_ofp` swallows everything.
+- **Failure scenario**: User enters a wrong SimBrief ID; SimBrief answers 400 with `{"fetch":{"status":"Error: Unknown UserID"}}`; the user sees "Could not fetch flight plan from SimBrief." and the log file contains nothing that says why.
+- **Suggested fix direction**: Use the `"Sim-CPDLC"` logger (or `getLogger("Sim-CPDLC").getChild(...)`) in `simbrief.py`; return an error string alongside `None`; fetch on a worker thread after the dialog is shown, or at least show a busy cursor.
+
+### 14. Manual weather requests run on the GUI thread
+
+- **Severity**: Low — the automatic path is threaded correctly; only the menu path freezes the UI for up to ~30 s on a stalled server.
+- **Confidence**: Confirmed.
+- **Location(s)**: `src/gui/main_window.py:734` → `src/model/cpdlc_session.py:494-508` → `src/model/connection_manager.py:451-477` (docstring itself says "callers that run on a timer should invoke this from a worker thread").
+- **Suggested fix direction**: Route the manual request through the same worker/`wx.CallAfter` pattern as `WeatherMonitor`.
+
+### Info-level observations (no user-visible defect found, noted for the coordinator)
+
+- `extract_message_content()` (`src/utils/message_formatting.py:6-17`) re-parses a packet the library already parsed; `CpdlcMessage.get_message()`, `get_mrn()`, `get_rr()` are authoritative and cannot drift from the library's grammar. The regex does strip every prefix shape the library emits (`/data2/N//RR/` and `/data2/N/M/RR/`), verified, so it is redundant rather than wrong. It is also applied to telex text, which is harmless only because telex is upper-cased and the pattern is lowercase `data`.
+- Every non-acknowledgement CPDLC uplink — including `LOGON ACCEPTED`, `LOGOFF`, `HANDOVER` and other `NE` messages that expect no reply — starts five minutes of 20 s polling (`should_increase_polling_rate`, `INACTIVITY_TIMEOUT`). Hoppie's 20 s allowance is for "while a reply is expected"; this is more generous than necessary but never faster than 20 s.
+- No `requests.Session` is used, so every poll/send is a fresh TCP+TLS handshake. Fine at these rates; it does mean each request can independently hit the 15 s connect timeout.
+- `install_request_timeout()`'s `timeout=15` is a per-phase value (connect and each socket read), not a total request budget; worst case for one hoppie call is ~30 s of GUI-thread stall. Only `requests.get`/`post` are wrapped, which is exactly what the library uses; the app's own calls pass explicit timeouts (15/10/5 s). No call without a timeout was found.
+- `on_disconnect` calls `set_active_polling()` and `wx.MilliSleep(500)` "to allow the message to be sent" after a fully synchronous send — both are no-ops in effect.
+- FANS-1/A MINs are modulo 64; `cpdlc_min_counter` grows without bound. Whether Hoppie ATC clients care is unverified — mentioned only because a long session with automatic handovers can pass 63.
+- `PollResponseParser` (`Responses.py:231`) uses `[^\}]*` for the packet, so a telex containing `}` is skipped with no warning at all (reproduced) — a library limitation, extremely rare in practice.
+- Logon codes are stored in plaintext in `config.json` and shown unmasked in Settings; consistent with the app's screen-reader-first design and with how every Hoppie client behaves.
+
+---
+
+## Things I checked that are fine
+
+- **Timeout patch reaches the library**: `hoppie_connector/API.py` uses module-attribute `requests.get`/`requests.post`; after `install_request_timeout()` both the library's GET (ping/poll/cpdlc) and POST (telex) arrived with `timeout=15` (reproduced). Idempotent via `_default_timeout_applied`; explicit timeouts still win.
+- **Every outbound call has a timeout**: hoppie calls (15 s via patch), inforeq (15 s explicit), SimBrief (10 s), GitHub (5 s).
+- **Error classification at the boundary**: builtin `ConnectionError` (library, non-2xx), `requests.RequestException` (incl. `SSLError`, `Timeout`, `HTTPError`, `JSONDecodeError`) → transport and counted; `ValueError`/`TypeError`/`UnicodeDecodeError` → protocol, not counted for sends, counted for polls (where there is no user input to blame); library `HoppieError` for `error {reason}` passes through; `poll()`'s broad `except` ensures nothing skips the counter. `OSError` is deliberately excluded (see finding 10 for the one consequence).
+- **Failure counters**: polls, sends and inforeq are counted separately; a successful poll does not clear send failures (proxy-blocks-POST case); weather failures never influence reconnection; all counters reset on connect/reconnect/disconnect. `should_attempt_reconnection()` requires a live `cnx` and credentials.
+- **Successful reconnection preserves the ATC logon**: `attempt_reconnection` rebuilds the connector under the same callsign and never touches `CpdlcSession`; from the station's side nothing changed.
+- **Credential redaction**: `redact()` covers the `?logon=` URL form that `requests` embeds in `ConnectionError`, `HTTPError` and friends (also `HoppieAPI.__repr__`'s `logon='…'` form); applied on every `HoppieError` built in `_call`/`_transport_failure`, and `poll()` redacts anything else it logs. No f-string in `src/` formats `logon_code`, the connector, or the API object. Both API URLs are HTTPS. `HoppieConnector` has no `__repr__` exposing the code.
+- **Callsign/recipient validation**: the library's `^[A-Z0-9]{3,8}$` is enforced on FROM at connect time by the `ping()` round trip and on TO at send time; both surface as `HoppieError` dialogs (whitespace is not stripped in the connect/telex dialogs, so the message is "Invalid FROM/TO station name" rather than a hint, but it is not silent). All CPDLC texts the app can generate (`REQUEST LOGON`, `LOGOFF`, `REQUEST FL350 DUE TO AIRCRAFT PERFORMANCE`, `REQUEST DIRECT TO KONOL`, `REQUEST M082`, `REQUEST 300K`, `WHEN CAN WE EXPECT …`, every response string) pass the library's `[A-Z0-9._@ ]+` check (verified). PDC telex is well under 220 chars.
+- **RR / MIN / MRN on downlinks**: `REQUEST LOGON` and all requests go out with `Y`; `LOGOFF` with `NE`; acknowledgements with `N` and `mrn=<uplink MIN>` (matches the real traffic quoted in TODOS.md); MIN increments after every successful send and not after a failed one.
+- **LOGON ACCEPTED validation**: station must match the pending station when one is pending; MRN must match the pending MIN when both are present; unsolicited acceptances (automatic transfer) still work; a 4-character station is required.
+- **HANDOVER / LOGOFF detection**: performed on `@`-normalised, whitespace-collapsed text; `^HANDOVER\s+([A-Z]{4})$` accepts `HANDOVER @EDUU@` and `HANDOVER EDUU`; only honoured from the current station; the app then sends `REQUEST LOGON` to the new station and enters active polling. `CURRENT ATC UNIT`/`CURRENT ATS UNIT` noise is hidden before it reaches the list.
+- **Messages from stations other than the current one** are displayed with sound but offer no responses (`needs_acknowledgement` compares sender to the live session station), so acknowledgements can never be misaddressed.
+- **Polling rate**: idle interval re-randomised in 45-75 s per tick, active 20 s, one-shot timer rescheduled in `finally`, `set_active_polling()` only pulls a pending poll forward when it is more than 20 s away and never restarts an imminent one; no code path polls faster than 20 s or issues bursts (the reconnection ping is one extra request per 3 failures; weather cycles are spaced 1 s and serialised by `_cycle_running`).
+- **`_send_info_request` request shape**: `from`/`to=SERVER`/`type=inforeq`/`packet=<kind> <ICAO>` matches Hoppie's documented inforeq; `ok {server info {…}}` unwrapping handles nested braces and multi-line bodies; `error {}` and HTML/captive-portal bodies raise; HTTP errors go through `raise_for_status` into the info counter.
+- **Weather monitor threading**: subscriptions mutated only on the GUI thread, snapshot handed to a daemon worker, results returned via `wx.CallAfter` guarded by `IsBeingDeleted()`, all exceptions (including OSError) caught on the worker, per-subscription failure cap of 5 with a SYSTEM message; timer stopped and subscriptions cleared on manual disconnect; interval clamped when read from config.
+- **Update checker**: background thread for the automatic check, explicit 5 s timeout, all exceptions (network absent, HTTP 403 rate limit, non-JSON, bad tag) caught and reduced to "could not retrieve"/silent; dialog scheduled via `CallAfter` only if the window is alive; manual check is synchronous but bounded.
+- **Global exception plumbing**: `sys.excepthook`, `threading.excepthook` and `OnExceptionInMainLoop` all log with traceback and show a dialog, so nothing dies silently in the `console=False` build (finding 1 is the one exception, because it is a *warning*, not an exception).

--- a/docs/audit/lens/2026-09-03-test-suite.md
+++ b/docs/audit/lens/2026-09-03-test-suite.md
@@ -1,0 +1,386 @@
+# Sim-CPDLC test-suite audit: test quality and coverage gaps
+
+Repo: `C:\Claude\sim-cpdlc` at `9c06458` (main). Read-only audit; nothing in the repo was modified and the suite was not run (only `--collect-only`: 135 tests across 14 files).
+
+Method: every file under `tests/` and `src/` plus `app.py`, `pytest.ini`, `tests/README.md`, `.github/workflows/tests.yml`, `requirements*.txt`, `TODOS.md`, the PR-24 spec, and `hoppie_connector` 0.2.1 (`__init__.py`, `API.py`, `Messages.py`, `Responses.py`, `CPDLC.py`, `Utilities.py`) were read in full. Claims marked *Confirmed* were checked either by reading both sides of the call or with small non-GUI Python snippets against the venv interpreter (Python 3.14.6, wxPython 4.2.5, requests 2.32.5, no `SimConnect` package installed).
+
+Facts established by snippet that the findings rely on:
+
+- The developer's real config exists at `C:\Users\robin\AppData\Local\Sim-CPDLC\Sim-CPDLC\config.json`, with `simbrief_userid` **set** and `auto_tune_com1: True` (only booleans were inspected).
+- `conftest.uplink(sender, min_value, text, rr)` builds `/data2/<min>//<rr>/<text>`: the MRN is always `None`.
+- `TelexMessage` has no `get_mrn`, and `extract_message_content("LOGON ACCEPTED")` returns the text unchanged.
+- `format_message_text("...FL360@@REPORT LEVEL@_@THEN.@CONTACT")` returns `'CLIMB TO AND MAINTAIN FL360N/AREPORT LEVEL\nTHEN.\nCONTACT'`.
+- `extract_contact_frequency("MONITOR 121.5")` returns `None`; `"CONTACT LANGEN RADAR 137.000"` returns `None`; `"CONTACT TOWER 118.10 WHEN READY"` returns `118.1`.
+
+---
+
+## 1. Findings
+
+### HIGH
+
+#### H1. The only end-to-end acknowledgement test throws away the response requirement and the own MIN it was written to protect
+
+- **Severity:** High  **Confidence:** Confirmed
+- **Location:** `tests/test_acknowledge_path.py:21-28`; production `src/model/cpdlc_session.py:226-233`; history `TODOS.md:66-74` (item 21, rated HIGH, "DONE").
+- **What is wrong:** `test_wilco_is_sent_with_the_senders_own_min_as_mrn` unpacks the recorded frame as `recipient, _own_min, _rr, text, mrn` and asserts only `(recipient, text, mrn)`. The RR value (`RR.NO.value == "N"`) and the client's own MIN are deliberately discarded. No other test in the suite observes the RR of an acknowledgement (`test_downlink_requests.py` never sends one; `test_connection_manager.py` never sends a CPDLC frame at all).
+- **Why it matters:** TODOS item 21 records that acknowledgements used to go out as `NE` and that "some ATC clients may not correctly process acknowledgements sent with `NE`". That fix has no regression test: reverting line 230 to `RR.NOT_REQUIRED.value` passes the whole suite. An unregistered WILCO is the single worst silent failure a CPDLC client can have. The own-MIN is equally unguarded: sending the ack with the *uplink's* MIN instead of the session counter would also pass.
+- **Evidence:**
+  ```python
+  recipient, _own_min, _rr, text, mrn = connection.sent[-1]
+  assert (recipient, text, mrn) == (STATION, "WILCO", 53)
+  ```
+- **Fix direction:** Assert the full frame: `connection.sent[-1] == (STATION, 1, RR.NO.value, "WILCO", 53)` (the session counter starts at 1 in `build()`), and add one test through the real `HoppieConnector` with a fake `requests.get` that captures `params["packet"]` and asserts the literal `/data2/1/53/N/WILCO`.
+
+#### H2. Hermeticity is per-test patchwork, not a fixture boundary: the real config file, `save_config`, SimBrief and SimConnect are each one unpatched call away
+
+- **Severity:** High  **Confidence:** Confirmed (mechanisms); no *current* test trips them
+- **Locations:**
+  - `tests/test_main_window.py:60-64` (`window` fixture patches `_check_first_launch`, `load_config`, `wx.MessageBox` only)
+  - `tests/test_dialogs.py:13-25` (`dialog` fixture patches nothing)
+  - `tests/conftest.py:94-115` (`make_main_window` patches nothing)
+  - `src/config.py:19-28` (import-time `os.makedirs` of the real user data dir; `CONFIG_FILE` bound to the real path)
+  - `src/gui/main_window.py:242,279` (`on_settings` reads via patched `load_config` but writes via **unpatched** `save_config`), `:1010` (`load_config()` on every uplink from the current station), `:1017` (`self.simconnect_manager.set_com1_standby_mhz`)
+  - `src/gui/dialogs/connect_dialog.py:27,62,79-90`, `src/gui/dialogs/pdc_dialog.py:27,53,95-106` (real `load_config()` then live `get_latest_ofp()` then a modal `wx.MessageBox` on failure)
+- **What is wrong:** Nothing redirects `src.config.CONFIG_FILE` to a temp path. Consequently:
+  1. Every test run creates the real `%LOCALAPPDATA%\Sim-CPDLC\Sim-CPDLC` directory at import time (benign, but it is a real-environment side effect on every developer and CI machine).
+  2. `window` fixture: `save_config` is not patched. The first test that drives `on_settings` (with `ShowModal` stubbed to `wx.ID_OK`) will `os.replace` the developer's real `config.json` with the patched defaults, wiping both logon codes and the SimBrief id. The fixture gives no warning.
+  3. `dialog` fixture: `ConnectDialog(frame)` or `PDCDialog(frame)` reads the developer's real config, and because `simbrief_userid` **is** set on this machine, performs a live HTTPS request to simbrief.com (10 s timeout) and, on any failure, opens a **modal** `wx.MessageBox` that hangs the run. `tests/README.md:22` says this file covers "each request dialog", which invites exactly these tests.
+  4. `make_main_window`: a HANDOVER, LOGOFF or CONTACT uplink from the current station reaches line 1010 and reads the developer's real config; with `auto_tune_com1: True` (the developer's actual value) and a frequency in the text, line 1017 dereferences `self.simconnect_manager`, which the fixture never sets. Through the real `window` fixture the same message would call the real `SimConnectManager`, which on a machine with MSFS running would retune COM1 standby in the live simulator.
+- **Why it matters:** The task definition of High includes "a fixture that can corrupt the developer's real environment or reach the network". Each of these is a confirmed capability of an existing fixture, guarded only by the absence of a test, and the README actively steers contributors toward writing the tests that would trigger 2 and 3.
+- **Evidence:** `tests/test_main_window.py:61-63`
+  ```python
+  monkeypatch.setattr(mw, "load_config", lambda: {**DEFAULT_CONFIG, "auto_check_updates": False})
+  ```
+  and `src/gui/main_window.py:279` `if save_config(config):` with no corresponding patch anywhere in `tests/`. `grep -n "save_config\|CONFIG_FILE" tests/*.py` returns nothing.
+- **Fix direction:** One autouse fixture in `conftest.py`: `monkeypatch.setattr(src.config, "CONFIG_FILE", str(tmp_path / "config.json"))` (both `load_config` and `save_config` read the module global at call time, and `_check_first_launch`'s local `from src.config import CONFIG_FILE` also binds at call time, so this covers all three); `monkeypatch.setattr("src.utils.simbrief.get_latest_ofp", ...)` at the two dialog import sites (they import the name, so patch `src.gui.dialogs.connect_dialog.get_latest_ofp` and `...pdc_dialog.get_latest_ofp`); and an autouse `requests.get/post` guard that raises if reached without an explicit `serving()` patch. Give `make_main_window` a `FakeSimConnectManager` and an explicit config dict.
+
+### MEDIUM
+
+#### M1. `make_main_window` can only exercise one of the five branches of `_on_message_received`; three session-state transitions have no test at all
+
+- **Severity:** Medium  **Confidence:** Confirmed
+- **Location:** `tests/conftest.py:94-115`; `src/gui/main_window.py:919-1027`.
+- **Attributes each branch touches, and what the fixture provides:**
+
+  | Branch (lines) | MainWindow attributes touched | Fixture state | Tested? |
+  |---|---|---|---|
+  | `CURRENT ATC/ATS UNIT` filter (926-934) | `logger` | OK | **No** |
+  | `LOGON ACCEPTED` (956-965) | `cpdlc_session`, `SetStatusText`, `logger` | OK | Yes (`test_logon_status.py`) |
+  | `HANDOVER XXXX` from current station (968-1000) | `cpdlc_session` (logoff+logon+callsign), `message_manager`, `message_view`, `polling_controller`, `SetStatusText`, `logger`, then **module-level `load_config()` (real file)** at 1010 | Works, but reads the developer's real config | **No** |
+  | `LOGOFF` from current station (1003-1007) | `cpdlc_session`, `SetStatusText`, `logger`, then real `load_config()` | Works, same caveat | **No** |
+  | CONTACT/MONITOR auto-tune (1009-1027) | real `load_config()`, **`simconnect_manager` (never set by fixture)**, `SetStatusText`, `logger` | `AttributeError` | **No** (untestable as-is) |
+  | message from a non-current station that is not `LOGON ACCEPTED` | nothing after `add_message` | OK | No (trivial) |
+
+  `_on_acknowledge_message` (1029-1064): unknown id and success paths touch only fixture-provided attributes and are tested; the **failure path (1058-1064) calls `wx.MessageBox`**, which is neither patched nor backed by a `wx.App` in `test_acknowledge_path.py` (those tests do not request `wx_app`), so "a failed acknowledgement is reported to the user" is untestable through this fixture and is untested.
+
+  Attributes the fixture never sets: `connection_manager`, `simconnect_manager`, `weather_monitor`, `update_checker`, `menu_item_connect`, `menu_item_logoff`, `panel`.
+- **Why it matters:** HANDOVER is the automatic re-logon to the next sector; a regression there strands the pilot without a station mid-flight. The LOGOFF branch decides whether the context menu keeps offering WILCO to a station that has dropped you. TODOS item 23 (exact matching so `LOGOFF NOT REQUIRED...` does not log off) has no regression test.
+- **Fix direction:** Extend `make_main_window` with `window.simconnect_manager = FakeSimConnectManager()` (records `set_com1_standby_mhz` calls) and patch `src.gui.main_window.load_config` to return a supplied dict; then add the branch tests listed in section 3.
+
+#### M2. `test_every_menu_item_has_a_handler` cannot detect the failure its module docstring promises to catch
+
+- **Severity:** Medium  **Confidence:** Confirmed
+- **Location:** `tests/test_main_window.py:1-10, 22-40, 177-182`; `src/gui/main_window.py:219-235`.
+- **What is wrong:** The docstring says "A handler renamed without its menu entry ... shows up here rather than as a dead menu item". The test only checks `callable(getattr(window, name))` for a hand-maintained list. Deleting any `self.Bind(wx.EVT_MENU, ...)` line (a genuinely dead menu item) passes, because the method still exists. Renaming a handler *and* its Bind passes production but fails the test spuriously. The comment "wx does not expose which handler a menu item is bound to" is not a blocker: `test_message_view.py:80-85` already drives menus by posting `wx.CommandEvent(wx.wxEVT_MENU, item.GetId())` through `ProcessEvent`, and the same technique works on the frame with each handler monkeypatched to a recorder.
+- **Fix direction:** For every item in every menu, monkeypatch the expected handler with a recorder, `window.ProcessEvent(wx.CommandEvent(wx.wxEVT_MENU, item.GetId()))`, and assert exactly one recorder fired. This also removes the duplicated `MENU_HANDLERS` list.
+
+#### M3. The MRN check on LOGON ACCEPTED is never exercised, and `test_logon_status.py` mislabels the MIN as the MRN
+
+- **Severity:** Medium  **Confidence:** Confirmed
+- **Location:** `tests/test_logon_status.py:15-16`; `tests/conftest.py:46-48`; `tests/test_cpdlc_session.py:17,27,37,46`; production `src/model/cpdlc_session.py:426-431`; `TODOS.md:89-92` (item 24).
+- **What is wrong:** `_logon_accepted_from(station, mrn)` passes `mrn` as `uplink`'s `min_value`, so the message on the wire is `/data2/1//NE/LOGON ACCEPTED` (MIN 1, **MRN None**). `_on_message_received` therefore always calls `handle_logon_accepted(sender, mrn=None)`, which skips the MRN comparison. In `test_cpdlc_session.py` every call uses either `mrn=None` or `mrn=1` against `pending_logon_min == 1`, so the rejecting branch (`mrn != self.pending_logon_min`, lines 427-431) is never entered by any test. Real traffic is `/data2/1/1/NE/LOGON ACCEPTED`.
+- **Why it matters:** Item 24 is marked DONE with no test; the one helper whose name says "mrn" does not set one. A future refactor could drop the MRN check unnoticed, and the status-bar tests would still pass.
+- **Fix direction:** Give `uplink` an `mrn=None` keyword and forward it to `CpdlcMessage`; rewrite `_logon_accepted_from` to send `min=1, mrn=<pending MIN>`; add `handle_logon_accepted("EDDF", mrn=2)` with pending MIN 1 → `False`.
+
+#### M4. Three of the six response-requirement rows are untested, including the two TODOS item 22 changed
+
+- **Severity:** Medium  **Confidence:** Confirmed
+- **Location:** `tests/test_message_manager.py:93-109` (covers `ROGER`, `NOT_REQUIRED`; `WILCO_UNABLE` elsewhere); production `src/model/message_manager.py:56-61`; `TODOS.md:76-82`.
+- **What is wrong:** `RR.YES → ["YES","NO"]`, `RR.NO → []` and `RR.AFFIRM_NEGATIVE → ["AFFIRM","NEGATIVE","STANDBY"]` have no test. Item 22 says the previous code offered only `YES` for `Y` and wrongly offered `NO` for `N`; the fix has no regression test.
+- **Fix direction:** One parametrised test over all six `CpdlcResponseRequirement` members asserting the exact list.
+
+#### M5. `PollingController` reconnection branch and `_report_connection_state` are unreachable by every test fake
+
+- **Severity:** Medium  **Confidence:** Confirmed
+- **Location:** `tests/test_polling_controller.py:85-102,149-153,184-200` (all fakes hard-code `poll_failed() → False`, `should_attempt_reconnection() → False`); production `src/controller/polling_controller.py:137-140, 182-196, 205-217`.
+- **What is wrong:** Untested: the not-connected tick that stops the timer (137-140); the "Connection problem (n/3) - retrying..." and "Connection restored." status texts (205-217); reconnection success → "Reconnected." and failure → "Connection lost. Reconnect to continue." followed by `stop()` (182-196); `_set_status` when the parent lacks `SetStatusText`. `test_a_poll_that_raises_still_schedules_the_next_one` proves the `finally` runs, but nothing proves the *deliberate* stop after a failed reconnection still ends polling (the comment at 144-146 says it should).
+- **Why it matters:** TODOS item 1 (Critical) was "polling can silently stop while the status bar still reads Connected". The status texts asserted nowhere are the only signal a screen-reader user gets (`README.md`: NVDA+End on the status bar).
+- **Fix direction:** A `FailingConnection` fake with settable `poll_failed`/`failure_count`/`should_attempt_reconnection`/`attempt_reconnection` and a parent recording `SetStatusText`; assert the exact texts and `is_running()` after each outcome.
+
+#### M6. Context-menu tests assert that *a* menu popped, not what it offers or that its items fire the right response
+
+- **Severity:** Medium  **Confidence:** Confirmed
+- **Location:** `tests/test_message_view.py:49-58`; production `src/gui/message_view.py:146-165`; `TODOS.md:11` (item 2, Critical: handler accumulation).
+- **What is wrong:** `test_menu_shown_for_a_message_from_the_current_station` asserts `len(panel.popped) == 1`. The stored object is a `wx.Menu` that `on_context_menu` destroys immediately afterwards, so nothing about its labels (`"Respond: WILCO"` ...) is or can be checked. The per-item lambda default-argument capture (`resp=response, mid=message_id`) and the post-popup `Unbind` (the fix for item 2) are unverified: a stale binding that fires the wrong response for a reused id would pass. The weather-menu test (61-90) shows the right pattern (drive each item through `ProcessEvent` inside the fake `PopupMenu`) but the CPDLC menu never got it.
+- **Fix direction:** In the fake `PopupMenu`, capture `[item.GetItemLabelText() for item in menu.GetMenuItems()]` and assert `["Respond: WILCO","Respond: UNABLE","Respond: STANDBY"]`; fire the second item and assert `on_acknowledge` received `(message_id, "UNABLE")`; after `on_context_menu` returns, re-post the same event id and assert no second acknowledgement.
+
+#### M7. The weather monitor's real threading path is only exercised by accident, and the cycle it starts is never awaited
+
+- **Severity:** Medium  **Confidence:** Confirmed
+- **Location:** `tests/test_weather_monitor.py:1-7, 32-36, 185-193`; production `src/model/weather_monitor.py:244-317`.
+- **What is wrong:** The module docstring says the tests "drive the result path directly", which is true for `_on_result`. `_run_cycle`/`_fetch_worker`/`_post_result`/`_post_cycle_finished` are reached only by `test_check_now_says_a_cycle_started`, which asserts `check_now() is True` and returns while a real daemon thread is still running against `ScriptedConnection`. That thread calls `self._parent.IsBeingDeleted()` off the GUI thread and posts two `wx.CallAfter`s that are flushed (if at all) by the `wx_app` teardown's `SafeYield`, after `frame.Destroy()` has been queued. Nothing asserts the `announced` result of the cycle; the `_cycle_running` re-entrancy guard, the `_shutting_down` break, and the `_REQUEST_SPACING_SECONDS` pacing are untested. Also untested: `set_interval` (`weather_monitor.py:135-145`), `subscribe` on an existing key re-seeding `text`/`signature` (166-173), and `error_count` reset after a success (348) — the property that four failures, a success and four more failures must **not** drop the subscription. `test_repeated_failures_drop_the_subscription` (129-144) cannot tell `MAX_CONSECUTIVE_ERRORS == 5` from `== 1`.
+- **Fix direction:** Make the worker deterministic: monkeypatch `threading.Thread` with a stub whose `start()` runs the target synchronously and `wx.CallAfter` with a direct call (or collect and replay), then assert `announced`, `_cycle_running` back to `False`, and that a second `check_now()` during a cycle returns `False`. Add the three unit tests named above and assert `count() == 1` after four failures.
+
+#### M8. Every session-level failure path is unreachable because `FakeConnectionManager` never raises, and most downlinks are never formatted
+
+- **Severity:** Medium  **Confidence:** Confirmed
+- **Location:** `tests/conftest.py:51-71`; `tests/test_downlink_requests.py` (7 tests, 2 message formats); production `src/model/cpdlc_session.py:95-97,130-134,189-191,234-236,260-262,293-295,334-336,363-365,390-392,488-490`.
+- **What is wrong:** Ten `except HoppieError: return False, str(exc)` branches and every corresponding `"Failed to send ..."` `wx.MessageBox` in `main_window.py` are uncovered. Untested formats: `logon` (`REQUEST LOGON`, `RR.YES`, counter reset to 1, pending state), `logoff` (`LOGOFF`, `RR.NOT_REQUIRED`, station cleared), `send_speed_request` (`REQUEST M082` vs `REQUEST 300K`), `send_when_can_we_expect` (passthrough), `send_telex`, `send_pdc_request` (`REQUEST PREDEP CLEARANCE <callsign> <type> TO <dest> AT <origin> STAND <n> ATIS <x>`, plus the `not self.callsign` precondition). `tests/README.md:23` claims "The exact text of every downlink the client can send"; the file's own docstring claims "the wire format" but asserts only the message element, never MIN/MRN/RR.
+- **Fix direction:** Give `FakeConnectionManager` an optional `raise_with=HoppieError(...)`; add one literal-text test per send method (section 3) and one connector-level test capturing the real `packet` param.
+
+#### M9. Nine of the ten dialogs have no test, and one of them cannot be built by the `dialog` fixture at all
+
+- **Severity:** Medium  **Confidence:** Confirmed
+- **Location:** `tests/test_dialogs.py` (WeatherDialog only); `src/gui/dialogs/telex_dialog.py:28` (`parent.get_current_station()` — a bare `wx.Frame` raises `AttributeError`); `tests/README.md:22`.
+- **What is wrong:** LogonDialog (4-char rule, TODOS 17), PDCDialog (TODOS 15), AltitudeChangeDialog (10..600, TODOS 16, `FL` prefix), DirectRequestDialog (2-5 alpha), SpeedRequestDialog (Mach padding `82 → 082`; note it also accepts two-digit knots, producing `REQUEST 30K`, which a test would have flagged), WhenCanWeDialog (value field show/hide and the five text formats), TelexDialog, ConnectDialog (which logon code is sent when the field is hidden — a credential-routing decision, `connect_dialog.py:205-212`), SettingsDialog (`get_settings` round trip and SpinCtrl bounds), WeatherSubscriptionsDialog (stop / stop-all / check-now / plural text). Three of the low-numbered TODOS "DONE" items are dialog validation fixes with no regression test.
+- **Fix direction:** Parametrised OK-button tests per dialog (set value → assert `ok_button.IsEnabled()`), plus `get_*_details()` literal assertions; give TelexDialog a `parent` stub with `get_current_station`; build ConnectDialog/PDCDialog only under the H2 config/SimBrief guards.
+
+#### M10. `load_config` / `save_config` are untested
+
+- **Severity:** Medium  **Confidence:** Confirmed
+- **Location:** `tests/test_config.py` (only `weather_interval_minutes`); production `src/config.py:41-92`; `TODOS.md:21` (item 5, atomic write, "DONE").
+- **What is wrong:** Missing-key back-fill, invalid-JSON fallback, IOError fallback, non-dict rejection, the temp-file-then-`os.replace` atomicity and the temp-file cleanup on failure have no test. These functions hold the logon codes; a regression corrupts or loses credentials.
+- **Fix direction:** Redirect `CONFIG_FILE` to `tmp_path` (see H2) and test each branch; for atomicity, monkeypatch `os.replace` to raise and assert the original file is intact and no `*.tmp` remains.
+
+#### M11. Four utility modules are entirely untested, two of them screen-reader- or simulator-facing
+
+- **Severity:** Medium  **Confidence:** Confirmed
+- **Location:** `src/utils/frequency_parser.py` (0 tests), `src/utils/message_formatting.py` (0 direct tests), `src/utils/simconnect_manager.py` (0), `src/utils/update_checker.py` (0), `src/utils/simbrief.py` (0; `src/utils/test_simbrief.py` is a live-API script, excluded by `testpaths`).
+- **What is wrong / evidence:** `format_message_text` and `format_list_text` produce `FL360N/AREPORT` for `FL360@@REPORT` (the `N/A` substitution has no surrounding spaces) and `LEVEL  THEN` (double space) — behaviour nobody has pinned, and this text is what NVDA reads. `extract_contact_frequency` decides what gets tuned into the simulator radio; the regex's range check, `ON`/`MHZ` handling, the `MONITOR 121.5` (no unit name) miss and multi-line messages are all unasserted. `SimConnectManager.set_com1_standby_mhz` has a retry that resets a module global; `UpdateChecker._is_newer_version` and the `IsBeingDeleted` guard from TODOS item 3 (Critical) are untested.
+- **Fix direction:** Pure-function tests for the parsers/formatters (table-driven); fake `SimConnect` module in `sys.modules` for the manager; fake `requests.get` returning a GitHub JSON body for the checker.
+
+#### M12. A TELEX whose body is `LOGON ACCEPTED`, `LOGOFF` or `HANDOVER XXXX` drives session state, and no test guards against it
+
+- **Severity:** Medium  **Confidence:** Plausible (production defect surfaced by the audit; the code path is confirmed, exploitation depends on network behaviour)
+- **Location:** `src/gui/main_window.py:946-1007`; `tests/` (no negative test).
+- **What is wrong:** The session-state branches gate on `hasattr(message, "get_packet_content") and hasattr(message, "get_from_name")`, which `TelexMessage` satisfies. `extract_message_content` passes telex text through unchanged, so a telex reading `LOGON ACCEPTED` from any station calls `handle_logon_accepted(sender, mrn=None)` (the MRN check is skipped because telexes have no `get_mrn`) and, with no logon pending, sets `current_station` and announces "Logged on to X". Any network participant can send a telex to a callsign.
+- **Fix direction:** Add `isinstance(message, CpdlcMessage)` to the gate; add tests that a telex with each of the three texts leaves `current_station` and `status_texts` unchanged.
+
+#### M13. `test_context_menu_follows_the_session_after_a_handover` never opens a context menu
+
+- **Severity:** Medium  **Confidence:** Confirmed
+- **Location:** `tests/test_main_window_wiring.py:44-58`.
+- **What is wrong:** After `Select(0)` the test calls `message_manager.needs_acknowledgement(message_id, station)` directly with `station = message_view.get_current_station()`. `on_context_menu` is never invoked, so the test would pass if the view stopped consulting `get_current_station` entirely. It restates `test_message_manager.py::test_a_message_from_another_station_offers_no_responses` one layer up; the first test in the file already proves the `get_current_station` wiring.
+- **Fix direction:** Shadow `PopupMenu` on `window.panel` as `test_message_view.py` does, call `window.message_view.on_context_menu(None)` before and after the handover, and assert the popup count goes 1 → 0.
+
+### LOW
+
+#### L1. Assertions weaker than their names
+
+- **Severity:** Low  **Confidence:** Confirmed
+- `tests/test_acknowledge_path.py:56` — `assert window.status_texts != []` for "tells the user"; the exact text `"Could not send response: message unavailable."` is available.
+- `tests/test_connection_manager.py:367` — `assert seen["timeout"] is not None`; should be `== NETWORK_TIMEOUT`.
+- `tests/test_connection_manager.py:335-342, 354-367` — information-request tests never assert the request params (`type == "inforeq"`, `to == "SERVER"`, `packet == "metar EDDF"` / `"vatatis EDDF"`); the wire keyword is asserted only via `report_type_packet` in `test_weather_parsing.py`, not on the actual request.
+- `tests/test_weather_monitor.py:150-154` — `test_unsubscribing_stops_the_updates` asserts the return value and count, never that a subsequent delivery is silent.
+- `tests/test_main_window.py:188-189` — `_require_connection` returns False, but with `wx.MessageBox` stubbed to a no-op nothing checks the user was told (capture the args instead of discarding them).
+- `tests/test_main_window.py:299-309` — `_on_weather_update` test asserts one chime; the status text `"New METAR EGLL"` and the new list row are not asserted.
+
+#### L2. The timeout tests permanently wrap `requests.post` for the rest of the session
+
+- **Severity:** Low  **Confidence:** Confirmed
+- **Location:** `tests/test_connection_manager.py:408-438`; `src/model/connection_manager.py:47-58`.
+- **What is wrong:** Both tests monkeypatch only `requests.get`. `install_request_timeout(7)` also wraps the genuine `requests.post` and tags it `_default_timeout_applied`; monkeypatch restores only `get`, so `requests.post` stays a 7-second-default wrapper for every later test and the real `install_request_timeout()` can never apply to `post` in-process again. Harmless today because every later `post` is re-patched, but it is a global mutation escaping its test.
+- **Fix direction:** Monkeypatch `requests.post` too (or have both tests use `serving`).
+
+#### L3. CI and environment robustness
+
+- **Severity:** Low  **Confidence:** Confirmed unless noted
+- `.github/workflows/tests.yml` has no `timeout-minutes` and the suite has no `pytest-timeout`; any unstubbed `ShowModal`/`wx.MessageBox` (H2, M1) hangs the job for GitHub's 6-hour default.
+- The test job installs the whole `requirements.txt`, including `pyinstaller==6.20.0`, which tests do not need (pip cache mitigates).
+- The local venv used for this audit diverges from the pins: `requests 2.32.5` (pinned `2.33.1`), `packaging 26.0` (pinned `26.2`), and neither `SimConnect` nor `pyinstaller` installed. A local green run is therefore not evidence the pinned CI set resolves and passes; verify the two pins exist on PyPI (*Plausible*: I could not check without network). `SimConnect>=0.4.26` is unbounded above.
+- The suite is Windows-only by design and cannot run headless on Linux without Xvfb; that is documented, but the README's "need a desktop session" also means a GitHub Windows runner is required (it works there).
+- `wx.App(clearSigInt=True)` per test resets SIGINT to default, so Ctrl-C during a run kills the process without pytest's teardown (cosmetic).
+
+#### L4. `tests/README.md` is out of date and overclaims
+
+- **Severity:** Low  **Confidence:** Confirmed
+- Table lists 12 files; `test_config.py` and `test_weather_parsing.py` are missing.
+- Line 22 "The validation each request dialog applies" — only `WeatherDialog` is tested.
+- Line 23 "The exact text of every downlink" — two message formats plus weather.
+- Line 25 "handlers" — existence check only (M2).
+- Line 21 "Session state and logon acceptance validation" — logon acceptance only.
+
+#### L5. `from conftest import ...` depends on the default `prepend` import mode
+
+- **Severity:** Low  **Confidence:** Confirmed
+- **Location:** `tests/test_acknowledge_path.py:3`, `test_cpdlc_session.py:3`, `test_downlink_requests.py:10`, `test_logon_status.py:8`, `test_main_window_wiring.py:12`, `test_message_manager.py:3`, `test_message_view.py:6`, `test_polling_controller.py:7`.
+- **What is wrong:** It works only because `tests/` has no `__init__.py` and pytest inserts the test file's directory on `sys.path`; `--import-mode=importlib`, a second `conftest.py` in a subdirectory, or running a single file from another cwd breaks it. pytest documents conftest as fixtures/hooks, not an import target.
+- **Fix direction:** Move `uplink`, the fakes and `make_main_window` to `tests/support.py` (or `tests/helpers/`).
+
+#### L6. The window-leak fix is not guarded, and the `wx.MessageBox` stub silently answers "No"
+
+- **Severity:** Low  **Confidence:** Confirmed
+- Commit `1360b20` measured zero live top-level windows after adding `wx.SafeYield()` to `wx_app` (`tests/conftest.py:34`), but no fixture asserts `wx.GetTopLevelWindows()` is empty at teardown, so the leak can return silently (e.g. a new module that builds its own `wx.App`, exactly what that commit fixed twice).
+- One `wx.App` per test is officially "one App per process" territory in wxPython; it works today (135 tests collected, CI green) but is the first place to look if the suite starts failing only in full runs.
+- `tests/test_main_window.py:64` stubs `wx.MessageBox` to return `None`; every `!= wx.YES` confirmation in `on_disconnect`, `on_logoff`, `_confirm_exit`, `on_stop_all` will silently take the cancel branch in any future test, which is a trap for "why does my disconnect test do nothing".
+
+#### L7. Repository hygiene visible from the tests
+
+- **Severity:** Low / Info  **Confidence:** Confirmed
+- `src/config.py:28` creates the real user data directory on import (every test file imports it).
+- `.pytest_cache` is not in `.gitignore` (one exists in the review worktree).
+- `src/utils/latest_simbrief_ofp.json` (161 KB of a real OFP) is tracked and is overwritten by the manual `test_simbrief.py` script; the script's `test_` name is one `pytest src` away from being collected and hitting the live API.
+- `MessageManager.get_weather_key` (`message_manager.py:164`) and `MessageView.clear` (`message_view.py:91`) have no callers in `src/` or `tests/`.
+
+### INFO
+
+- Near-duplicates: `test_main_window.py::test_a_subscribed_report_reads_as_watched` is subsumed by `test_the_context_menu_toggle_stops_and_restarts_updates`; `test_a_weather_request_reports_the_code_in_upper_case` (dialogs) and `test_the_weather_dialog_always_opens_on_atis` (main window) both pin the `vatatis` default; `test_a_poll_that_raises_still_schedules_the_next_one` and `test_a_dropped_message_is_logged_before_it_propagates` duplicate their whole setup. Layered repeats across `test_message_manager` / `test_message_view` / `test_main_window_wiring` for "other station → no responses" are acceptable, except M13.
+- The `window` fixture calls the real `MainWindow.__init__`, which `Show(True)`s a frame before the fixture hides it; the sound path is resolved from the cwd (`main_window.py:56-64`), so running from anywhere but the repo root silently takes the "sound missing" branch (with the stubbed MessageBox). Both harmless, both worth knowing.
+- `tests/test_polling_controller.py:38-49` is statistical (mean of 2000 uniform draws within ±3000 of 60000 ≈ 15σ); not a flake risk.
+
+---
+
+## 2. Coverage map
+
+Legend: **Risk** is the consequence of an undetected regression in that item, for untested items only.
+
+| Production module / behaviour | Tested by | Risk if untested |
+|---|---|---|
+| `app.py` `_install_exception_handlers`, `SimCpdlcApp.OnExceptionInMainLoop` | UNTESTED | Low |
+| `config.py` `weather_interval_minutes` | `test_config.py::*` (5) | — |
+| `config.py` `load_config` (back-fill / bad JSON / IOError) | UNTESTED | Medium |
+| `config.py` `save_config` (atomic write, non-dict) | UNTESTED | Medium |
+| `logging_setup.setup_logging` | UNTESTED | Low |
+| `ConnectionManager.install_request_timeout` | `test_connection_manager.py::test_install_request_timeout_supplies_a_default`, `::test_an_explicit_timeout_still_wins` | — |
+| `ConnectionManager.redact` / logon code never in error text | `::test_redact_removes_the_logon_code`, `::test_the_logon_code_never_reaches_the_error_text` | — |
+| `_call` transport/protocol conversion, counters | `::test_message_validation_failures_surface_as_hoppie_error[3]`, `::test_a_bad_http_status_...`, `::test_an_unparseable_body_...`, `::test_a_local_os_error_...`, `::test_a_rejected_message_...` | — |
+| `connect` / `_open` (ping verifies link, callsign validation) | `::test_connect_succeeds_...`, `::test_connect_fails_when_the_server_is_down`, `::test_connect_rejects_a_callsign_...` | — |
+| `disconnect` clears state | `::test_disconnect_clears_everything_connect_set` | — |
+| `disconnect` when not connected (no-op) | UNTESTED | Low |
+| `poll` failure counting, unparseable body, reset on success | `::test_transport_failures_during_polling_...`, `::test_an_unparseable_poll_response_also_counts`, `::test_poll_reports_failure_without_raising`, `::test_a_successful_poll_clears_the_failure_state` | — |
+| `poll` when not connected → `(None, None)` | UNTESTED | Low |
+| `failure_count` / `poll_failed` / `should_attempt_reconnection` (send failures survive polls; no cnx) | `::test_send_failures_survive_a_successful_poll`, `::test_no_reconnection_without_a_live_connection` | — |
+| `attempt_reconnection` success / server down | `::test_reconnection_succeeds_once_the_server_recovers`, `::test_reconnection_reports_failure_...` | — |
+| `attempt_reconnection` with missing credentials → False | UNTESTED | Low |
+| `send_cpdlc` (wire packet `/data2/MIN/MRN/RR/TEXT`, not-connected error) | UNTESTED at the HTTP layer | Medium |
+| `send_telex` | `::test_message_validation_failures_...`, `::test_a_bad_http_status_...` | — |
+| `_send_info_request` envelope unwrap / server error / timeout / not connected / own failure counter | `::test_an_information_request_unwraps_the_server_envelope[2]`, `::_reports_a_server_error[2]`, `::_sends_a_timeout`, `::_requires_a_connection`, `::test_a_failing_weather_request_does_not_trip_reconnection`, `::test_a_weather_request_that_recovers_clears_its_own_count` | — |
+| `_send_info_request` "Unexpected response" branch (447-449); request params (`inforeq`, `packet`) | UNTESTED | Low |
+| `send_info_request` empty body → `No METAR available` | UNTESTED | Low |
+| `PollingController.next_interval` band / active | `test_polling_controller.py::test_idle_polls_are_spread_...`, `::test_active_mode_polls_at_the_fastest_rate_permitted` | — |
+| `start` / `stop` / `_schedule_next` after stop | `::test_a_stopped_poller_does_not_reschedule_itself` | — |
+| `on_poll_timer` callback raises → logged and still rescheduled | `::test_a_poll_that_raises_still_schedules_the_next_one`, `::test_a_dropped_message_is_logged_before_it_propagates` | — |
+| `on_poll_timer` when not connected → stop | UNTESTED | Medium |
+| `_report_connection_state` ("Connection problem (n/3)", "Connection restored.") | UNTESTED | High |
+| Reconnection branch ("Reconnected." / "Connection lost..." + stop) | UNTESTED | High |
+| `set_active_polling` deadline logic, mid-tick guard | `::test_repeated_activity_does_not_defer_a_pending_poll`, `::test_an_idle_poll_is_pulled_forward_...`, `::test_a_message_that_speeds_up_polling_mid_tick_still_schedules_once` | — |
+| `check_polling_timeout` | `::test_a_quiet_period_returns_to_the_randomised_band` | — |
+| `should_increase_polling_rate` (acks, clearance) | `::test_a_bare_acknowledgement_does_not_speed_up_polling`, `::test_a_clearance_speeds_up_polling` | — |
+| `should_increase_polling_rate` for `TelexMessage` → False | UNTESTED | Low |
+| `CpdlcSession.logon` happy path, MIN reset, pending tracking | partially via `test_cpdlc_session.py`, `test_logon_status.py` (wire MIN/RR not asserted) | Medium |
+| `logon` preconditions (not connected, bad length) / HoppieError | UNTESTED | Low / Medium |
+| `logoff` / `send_logoff_message` | UNTESTED | Medium |
+| `send_altitude_change_request` text, counter, preconditions | `test_downlink_requests.py::*` (5) | — |
+| `send_acknowledgement` recipient/MRN | `test_acknowledge_path.py::test_wilco_is_sent_with_the_senders_own_min_as_mrn` | — |
+| `send_acknowledgement` RR (`N`) and own MIN | UNTESTED (H1) | High |
+| `send_acknowledgement` sender ≠ current station warning | UNTESTED | Low |
+| `send_direct_request` | `test_downlink_requests.py::test_a_weather_reason_is_unchanged` | — |
+| `send_speed_request` (Mach / knots) | UNTESTED | Medium |
+| `send_when_can_we_expect` | UNTESTED | Low |
+| `send_telex` (session) | UNTESTED | Low |
+| `send_pdc_request` (text, callsign precondition) | UNTESTED | Medium |
+| `request_weather` / `_request_info` | `test_downlink_requests.py::test_a_weather_request_*` | — |
+| `handle_logon_accepted` station mismatch / unsolicited / invalid name | `test_cpdlc_session.py::*` (4) | — |
+| `handle_logon_accepted` MRN mismatch → False | UNTESTED (M3) | Medium |
+| `handle_station_logoff` current station | `test_main_window_wiring.py::test_context_menu_follows_...` | — |
+| `handle_station_logoff` non-current station (warning only) | UNTESTED | Low |
+| `MessageManager.add_message` / `add_custom_message` / `add_weather_message` | many | — |
+| `add_message` with non-HoppieMessage → -1 | UNTESTED | Low |
+| `get_cpdlc_addressing` | `test_message_manager.py::test_get_cpdlc_addressing_*` (3) | — |
+| Display/detail: `WeatherReport` | `::test_a_weather_report_reaches_the_reader_without_separators`, `test_main_window.py::test_a_weather_message_is_tagged_...` | — |
+| Display/detail: `CpdlcMessage` (`format_list_text`/`format_message_text`) | UNTESTED | Medium |
+| Display/detail: `TelexMessage`; custom without sender ("SYSTEM"); unknown id | UNTESTED | Low |
+| Display/detail: custom with sender, list flattened | `test_main_window.py::test_a_multi_line_message_is_flattened_...` | — |
+| `mark_acknowledged` / `needs_acknowledgement` / STANDBY / reused MIN / other station | `test_message_manager.py::*` (8) | — |
+| `RESPONSES_BY_REQUIREMENT`: `WU`, `R`, `NE` | `test_message_manager.py::test_a_reused_min_...`, `::test_a_roger_message_...`, `::test_a_message_needing_no_response_...` | — |
+| `RESPONSES_BY_REQUIREMENT`: `AN`, `Y`, `N` | UNTESTED (M4) | Medium |
+| `WeatherMonitor.subscribe` new (+`initial_text`) / `unsubscribe` / `is_subscribed` / `count` | `test_weather_monitor.py::*`, `test_main_window.py::*` | — |
+| `subscribe` existing key re-seeds text/signature | UNTESTED | Medium |
+| `get_subscriptions` ordering; `clear` | UNTESTED (clear used in teardown only) | Low |
+| `start` / `stop` / `shutdown` | `::test_the_monitor_can_be_stopped_and_started_again` | — |
+| `set_interval` | UNTESTED | Medium |
+| `check_now` guards (stopped / no subscriptions / started) | `::test_check_now_says_*` (3) | — |
+| `_run_cycle` cycle-running guard, not-connected guard | UNTESTED | Low |
+| `_fetch_worker` / `_post_result` / `_post_cycle_finished` (thread path) | incidental only (M7) | Medium |
+| `_on_result` first / same letter / new letter / METAR text / error drop | `::test_the_first_report_is_announced` ... `::test_repeated_failures_drop_the_subscription` | — |
+| `_on_result` error_count reset after success; unsubscribed in flight | UNTESTED | Medium / Low |
+| `weather_parsing.*` (types, letters, D-ATIS, formatters, signatures) | `test_weather_parsing.py::*` (17) | — |
+| `MessageView` single-selection, add_message, other-station no menu, weather menu callback | `test_message_view.py::*` (4) | — |
+| `on_context_menu` item labels / binding / Unbind cleanup | UNTESTED (M6) | Medium |
+| `on_message_selected` → detail pane text | UNTESTED | Medium |
+| `on_context_menu` with no selection; `add_message` unknown id; `clear` | UNTESTED | Low |
+| `MainWindow._init_ui` / `_init_menu` shape, mnemonics, station wiring | `test_main_window.py::test_the_menu_bar_*`, `::test_the_requests_menu_*`, `::test_no_mnemonic_collides_*`, `test_main_window_wiring.py::test_init_ui_wires_*` | — |
+| Menu item → handler binding | UNTESTED (M2: existence only) | Medium |
+| `on_connect` (dialog result → connect → start polling+weather → status/menu label) | UNTESTED | High |
+| `on_disconnect` (confirm, logoff first, stop timers, clear subscriptions, menu label) | UNTESTED | High |
+| `on_logon` / `on_logoff` | UNTESTED | Medium |
+| `on_altitude_change` / `on_direct_request` / `on_speed_request` / `on_when_can_we_expect` / `on_telex` / `on_pdc_request` | UNTESTED | Medium |
+| `_require_connection` False branch | `test_main_window.py::test_a_request_needing_a_connection_is_refused_while_disconnected` | — |
+| `on_weather_request` (unsubscribe-on-uncheck, subscribe-on-success, failure box) | UNTESTED | Medium |
+| `on_weather_subscriptions` | UNTESTED | Low |
+| `on_settings` (+ `set_interval`, `save_config`) | UNTESTED | Medium |
+| `on_check_updates` / `on_about` / `on_exit` | UNTESTED | Low |
+| `_on_weather_update` chime | `::test_a_changed_report_announces_itself`, `::test_a_report_the_pilot_asked_for_arrives_quietly` | — |
+| `_on_weather_error` | UNTESTED | Low |
+| `_add_weather_message` / `_is_weather_watched` / `_on_toggle_weather_updates` / `_add_custom_message` | `test_main_window.py::*` | — |
+| `_on_message_received`: `CURRENT ATC/ATS UNIT` filter | UNTESTED | Medium |
+| `_on_message_received`: `LOGON ACCEPTED` accepted / rejected | `test_logon_status.py::*` (2) | — |
+| `_on_message_received`: `HANDOVER` | UNTESTED (M1) | High |
+| `_on_message_received`: `LOGOFF` from current station (and exact-match negatives) | UNTESTED (M1) | Medium |
+| `_on_message_received`: CONTACT/MONITOR auto-tune, `auto_tune_com1` off, SimConnect failure status | UNTESTED (M1; blocked by fixture) | Medium |
+| `_on_acknowledge_message` success / STANDBY / unknown id / custom id | `test_acknowledge_path.py::*` (5) | — |
+| `_on_acknowledge_message` send failure → MessageBox | UNTESTED (blocked by fixture) | Medium |
+| `on_close` / `_confirm_exit` (veto, logoff on exit, shutdown order) | UNTESTED | Medium |
+| `_check_first_launch` | UNTESTED (patched out) | Low |
+| `WeatherDialog` (ICAO rule, upper-case, checkbox latch, mirrors watched state, ATIS default) | `test_dialogs.py::*` (4), `test_main_window.py::test_the_checkbox_mirrors_*`, `::test_the_weather_dialog_always_opens_on_atis` | — |
+| `LogonDialog`, `AltitudeChangeDialog`, `DirectRequestDialog` | UNTESTED | Low |
+| `PDCDialog`, `SpeedRequestDialog`, `WhenCanWeDialog`, `ConnectDialog`, `SettingsDialog`, `WeatherSubscriptionsDialog`, `TelexDialog` | UNTESTED (M9) | Medium |
+| `about_dialog.show_about_dialog` | UNTESTED | Low |
+| `utils.frequency_parser.extract_contact_frequency` | UNTESTED | Medium |
+| `utils.message_formatting.extract_message_content` | indirect only (no direct assertion) | Low |
+| `utils.message_formatting.format_list_text` / `format_message_text` | UNTESTED | Medium |
+| `utils.simconnect_manager.SimConnectManager` | UNTESTED | Medium |
+| `utils.update_checker.UpdateChecker` | UNTESTED | Low |
+| `utils.simbrief.get_latest_ofp` | UNTESTED (live script only) | Low |
+
+---
+
+## 3. Recommended new tests (prioritised)
+
+1. **Acknowledgement frame is complete** (`test_acknowledge_path.py`): after WILCO, `connection.sent[-1] == (STATION, 1, RR.NO.value, "WILCO", 53)`; a second ack uses own MIN 2. Then one test through the real `HoppieConnector` with a capturing `requests.get`: `params["packet"] == "/data2/1/53/N/WILCO"`.
+2. **Hermetic conftest** (autouse): `CONFIG_FILE` → `tmp_path`; `requests.get/post` guard that raises unless a test installs `serving()`; SimBrief `get_latest_ofp` patched at both dialog import sites; assert `wx.GetTopLevelWindows()` is empty after `wx_app` teardown. Assertion: a test that calls `save_config({})` leaves the real user data dir untouched.
+3. **HANDOVER via the window** (`make_main_window` + fake simconnect + injected config): logged on to EDYY, receive `HANDOVER EDGG` → `session.get_current_station() == ""`, `connection.sent[-1] == ("EDGG", 1, "Y", "REQUEST LOGON", None)`, `status_texts == ["Logged off from EDYY.", "Pending logon to EDGG."]`, `polling_controller.active_calls == 1`. Negative: `HANDOVER EDGG` from a non-current station changes nothing.
+4. **LOGOFF via the window**: `LOGOFF` from the current station clears the station and sets `"Logged off from EDYY."`; `LOGOFF` from another station and `LOGOFF NOT REQUIRED AT THIS TIME` from the current station both leave the station logged on (TODOS 23).
+5. **CURRENT ATC UNIT filter**: `/data2/5//NE/CURRENT ATC UNIT@_@EDGG@_@RHEIN RADAR` from the current station → `message_view.added == []`, `message_manager.message_log == {}`, no status text; `CURRENT ATS UNIT` likewise.
+6. **CONTACT/MONITOR auto-tune**: `CONTACT MARSEILLE CONTROL 133.325` from the current station with `auto_tune_com1: True` → fake simconnect received `133.325`; with `False` → nothing; with the fake returning False → `status_texts[-1] == "Auto-tune failed \u2014 set 133.325 manually"`; same message from a non-current station → nothing tuned.
+7. **Telex bodies do not drive session state** (M12): `TelexMessage("EDGG","DLH123","LOGON ACCEPTED")` (and `LOGOFF`, `HANDOVER EDDF`) → `current_station` unchanged, `status_texts == []`.
+8. **PollingController link reporting**: a fake whose `poll_failed()` is True and `failure_count()` is 2 → parent status `"Connection problem (2/3) - retrying..."`; then False → `"Connection restored."`; `should_attempt_reconnection()` True + `attempt_reconnection()` False → `"Connection lost. Reconnect to continue."` and `is_running() is False` even though `finally` ran; True → `"Reconnected."` and still running; `is_connected()` False on a tick → timer stopped, no poll.
+9. **MRN validation**: `handle_logon_accepted("EDDF", mrn=2)` with pending MIN 1 → False, station `""`; via the window with a properly built `/data2/1/2/NE/LOGON ACCEPTED` → `status_texts == []`. Fix `uplink` to accept `mrn`.
+10. **Response table completeness**: parametrise over all six `CpdlcResponseRequirement` members: `WU → [WILCO,UNABLE,STANDBY]`, `AN → [AFFIRM,NEGATIVE,STANDBY]`, `R → [ROGER,STANDBY]`, `Y → [YES,NO]`, `N → []`, `NE → []`.
+11. **Context menu contents and cleanup** (`test_message_view.py`): labels `["Respond: WILCO","Respond: UNABLE","Respond: STANDBY"]`; firing item 2 calls `on_acknowledge(message_id, "UNABLE")`; re-posting the same id after the menu closed fires nothing (TODOS 2).
+12. **Every downlink literally** (`test_downlink_requests.py`): `logon` → `("EGGX", 1, "Y", "REQUEST LOGON", None)` and counter back to 1 after prior sends; `logoff` → `("EGGX", n, "NE", "LOGOFF", None)` and station cleared; `send_speed_request("082", True)` → `REQUEST M082`, `("300", False)` → `REQUEST 300K`; `send_pdc_request` → exact upper-cased telex to the origin; `send_when_can_we_expect` passthrough; each with `FakeConnectionManager(raise_with=HoppieError("boom"))` → `(False, "boom")`.
+13. **Weather monitor determinism**: with `threading.Thread` run synchronously and `wx.CallAfter` direct, `check_now()` on the `atis` fixture announces once; a second `check_now()` while `_cycle_running` → False; four errors then a success then four errors → `count() == 1`; `subscribe` on an existing key with new text updates `signature`; `set_interval(120000)` restarts a running timer with `GetInterval() == 120000`.
+14. **Dialogs**: per-dialog OK-button tables (Logon 3/4/5 chars; Altitude 9/10/600/601/"abc"; Direct "A"/"AB"/"ABCDE"/"ABCDEF"/"AB1"; Speed Mach "8"/"82"/"082"/"0820", knots; WhenCanWe each type and `get_message_text` literals; PDC all-fields rule; Telex both fields with a `get_current_station` stub parent), `SettingsDialog.get_settings` round trip, `ConnectDialog.get_connection_details` returns the saved code for the selected network when the field is hidden and the typed code otherwise (with `load_config` patched).
+15. **`load_config` / `save_config`** on `tmp_path`: back-fill of a missing key, invalid JSON → defaults, non-dict → False, `os.replace` failure leaves the original intact and no `.tmp` behind.
+16. **`frequency_parser` table**: the ten cases in the preamble, plus a multi-line message and `136.990` / `137.000` at the boundary; **`message_formatting` table** pinning `@@`, `_`, punctuation-joining and the `/data2/19/1/NE/` prefix strip.
+17. **`on_connect` / `on_disconnect` / `on_close`** through the real `window` fixture with `ConnectDialog.ShowModal` stubbed to `ID_OK` and `get_connection_details` stubbed, `connection_manager.connect` faked, `wx.MessageBox` stubbed to `wx.YES`, and `wx.MilliSleep` patched: polling and weather timers start/stop, menu label flips, status texts and system messages appear, `send_logoff_message` is sent before disconnect when logged on, `_confirm_exit` vetoes on "No".
+18. **Menu binding** (replaces M2's list): post `wxEVT_MENU` for each item and assert the intended handler recorder fired once.
+19. **`on_message_selected`**: selecting a row puts `get_message_detail_text` into `message_detail` (the pane NVDA reads).
+20. **`UpdateChecker._is_newer_version`** and `_check_in_background` not calling `wx.CallAfter` when `parent.IsBeingDeleted()` (TODOS 3); **`SimConnectManager.set_com1_standby_mhz`** with a fake `SimConnect` module: Hz conversion `134.750 → 134750000`, retry after `send_event` failure, False when import fails.
+
+---
+
+## 4. Things I checked that are fine
+
+- **No current test reaches the network or writes the real config.** Every `hoppie_connector` call in `test_connection_manager.py` goes through `serving()`/explicit monkeypatches of both `requests.get` and `requests.post`; `connected()` patches both before `connect()`; the `.invalid` TLD is used for the timeout tests. The `window` fixture's `auto_check_updates: False` keeps `UpdateChecker` off its thread; `_check_first_launch` is patched so no `save_config`; `HeadlessMainWindow` and `make_main_window` skip `__init__` entirely; only `WeatherDialog` (which does not read config) is ever constructed. `test_logon_status.py` never reaches line 1010 because `LOGON ACCEPTED` takes the earlier branch.
+- **`test_connection_manager.py` is a genuinely good boundary test.** Faking `requests` rather than the connector keeps the library's own validators and parsers in the path (verified against `Messages.py:146-149,635-640`, `API.py:46-47`, `Responses.py:197-199`), so the ValueError/ConnectionError/HTTPError conversions, the OSError pass-through (`FileNotFoundError` is not in `TRANSPORT_ERRORS`), the send-vs-poll-vs-info counters and the credential redaction are all exercised for real.
+- **The pytest-run-controller tests are real.** `test_a_message_that_speeds_up_polling_mid_tick_still_schedules_once` correctly shadows `_schedule_next` on the instance, stops the one-shot to reproduce `IsRunning() == False`, and would catch removal of the guard at `polling_controller.py:715`. The deadline tests cannot flake (a 20 s deadline cannot be further than 20 s away).
+- **`test_dialogs.py::_fire_auto_update_toggle`** drives a real `wx.EVT_CHECKBOX` through `ProcessEvent`, so deleting the `Bind` at `weather_dialog.py:91` is caught, as commit `611f422` intended.
+- **`test_the_weather_menu_hands_back_the_report_it_was_opened_on`** is the model for menu tests: it fires each item through `ProcessEvent` and verifies the closure captured the right report.
+- **`test_message_manager.py::test_a_reused_min_does_not_suppress_a_later_message`** is a precise regression test for the ID-keyed acknowledgement set.
+- **`test_weather_parsing.py`** covers the registry, D-ATIS designator, NATO spelling, time-group stripping and both formatters with literal expectations; `test_the_dialog_offers_every_report_type` correctly ties `REPORT_ORDER` to `REPORT_TYPES`.
+- **Mnemonic-collision test** reads `GetItemLabel()` (keeps `&`) and handles `&&`; it is a real accessibility guard.
+- **Fixture teardown order** is sound: `dialog` → `frame` → `wx_app`; `frame.Destroy()` is queued before `wx.SafeYield()` runs in `wx_app`, and commit `1360b20` records that this brought the live-window count to zero. The `logger` fixture resets handlers each test, so the `caplog.handler` attached in `test_a_dropped_message_is_logged_before_it_propagates` does not leak.
+- **`pytest.ini`** correctly scopes collection to `tests/` (the live-API script under `src/utils/` is excluded) and `pythonpath = .` makes `import src...` work without installing the package.
+- **CI workflow** picks the right OS for a wxPython suite, pins Python 3.13, caches pip on both requirements files, and runs on push to `main` and on every PR. `SimConnect>=0.4.26` is a pure-Python package bundling its DLL and installs on the Windows runner without a simulator present.
+- **`hoppie_connector` objects the tests build are realistic**: station names satisfy `^[A-Z0-9]{3,8}$`, message bodies satisfy `[A-Z0-9\.\_\@ ]+`, and `RR` members are the real `CpdlcResponseRequirement` enum, so `get_packet_content()` on every fixture message is a legal Hoppie packet.

--- a/docs/audit/lens/2026-09-03-threading-lifecycle.md
+++ b/docs/audit/lens/2026-09-03-threading-lifecycle.md
@@ -1,0 +1,700 @@
+# Sim-CPDLC audit: threading, concurrency, wx event loop, object lifecycle
+
+Scope: `app.py` and every file under `src/` (read in full), `tests/conftest.py`,
+`tests/test_weather_monitor.py`, `tests/test_polling_controller.py`,
+`tests/test_main_window.py` (plus the other test files for context),
+`hoppie_connector` 0.2.1 (`__init__.py`, `API.py`, `Messages.py`, `Responses.py`,
+`Utilities.py`), and the wxPython 4.2.5 / wxWidgets 3.2.9 sources for the
+behaviours the findings depend on.
+
+Verification basis (things checked rather than assumed):
+
+- `wx.Timer.Destroy` exists in wxPython 4.2.5 (runtime check), so
+  `WeatherMonitor.shutdown()` is valid.
+- `wx.CallAfter` asserts `wx.GetApp() is not None` (`wx/core.py:3418-3431`;
+  runtime check raises `AssertionError: No wx.App created yet`), and
+  `wxAppConsoleBase::~wxAppConsoleBase` sets `ms_appInstance = NULL`, so
+  `wx.GetApp()` is `None` once the `wx.App` object has been collected.
+- sip raises `RuntimeError: wrapped C/C++ object of type X has been deleted`
+  for any method call on a proxy whose C++ object is gone (string present in
+  `siplib.pyd`).
+- wxPython's event thunker calls `PyErr_Print()` when a Python handler raises
+  (Phoenix `src/event_ex.cpp`), i.e. `sys.excepthook` runs *inside* the
+  failing handler's dispatch and no C++ exception is thrown.
+- wxMSW `wxProcessTimer` calls `Stop()` on a one-shot timer *before*
+  `Notify()`, and a WM_TIMER queued before `Stop()` is discarded because
+  `Stop()` erases the id from the timer map (`src/msw/timer.cpp`).
+- `wxTopLevelWindowBase::Destroy()` only appends to `wxPendingDelete`; it does
+  not call `SendDestroyEvent()`. For a frame, `m_isBeingDeleted` is first set
+  in `~wxFrameBase` / `~wxWindowMSW`, i.e. inside the destructor.
+  `~wxWindowMSW` calls `DestroyChildren()`, which deletes child windows
+  immediately (`child->wxWindowBase::Destroy()`), and `~wxDialog` calls
+  `Show(false)`, which calls `m_modalData->ExitLoop()`.
+- `wxWindowMSW::DoPopupMenu` calls `wxYieldForCommandsOnly()` after
+  `TrackPopupMenu`, so the selected item's handler runs before `PopupMenu()`
+  returns.
+- `wx.App.__init__(..., clearSigInt=True)` installs `SIG_DFL` for SIGINT
+  (`wx/core.py:2143`, `2188-2193`).
+- `requests`: a scalar `timeout=15` is both the connect and the read timeout,
+  and the read timeout applies to each socket read, not to the whole response
+  (urllib3 `Timeout` docs); DNS resolution is not covered at all.
+- Python-SimConnect (upstream `SimConnect/SimConnect.py`; the package is not
+  installed in the venv): `connect()` busy-waits `while self.ok is False:
+  pass` after a successful `Open`, `send_event()` returns `False` on failure
+  (it does not raise), `map_to_sim_event()` returns `None` on failure,
+  `exit()` joins the daemon dispatch thread.
+
+Items in `TODOS.md` / the PR-24 spec were checked against the current code and
+are fixed as described; finding 6 below refines TODO #3.
+
+---
+
+## Findings (ordered by severity)
+
+### 1. Every network operation runs synchronously on the GUI thread; worst-case freezes of 15-60 s per operation with no feedback
+
+- **Severity**: High. The client is a screen-reader-first tool, and in degraded
+  network conditions it becomes silently unresponsive for tens of seconds at a
+  time, repeatedly, with no way to cancel.
+- **Confidence**: Confirmed (code paths and timeout semantics verified; durations
+  are derived from the constants in the code).
+- **Location(s)**:
+  `src/config.py:147` (`NETWORK_TIMEOUT = 15`);
+  `src/model/connection_manager.py:221-222` (connect: `HoppieConnector` + `ping`),
+  `:286` (poll), `:368-373`/`:388` (sends), `:423` (inforeq GET);
+  `src/controller/polling_controller.py:149` (poll inside the timer handler),
+  `:186` (reconnection inside the same tick);
+  `src/gui/main_window.py:324` (connect), `:380` and `:1085` (logoff on
+  disconnect/close), `:734` (manual weather), `:986` (handover logon inside the
+  poll tick), `:1017` (SimConnect inside the poll tick), `:386` (`MilliSleep`);
+  `src/gui/dialogs/connect_dialog.py:62` and `src/gui/dialogs/pdc_dialog.py:53`
+  (SimBrief fetch inside the dialog constructor, `src/utils/simbrief.py:28-32`,
+  `timeout=10`);
+  `src/utils/update_checker.py:40`, `:97` (manual check, `timeout=5`).
+- **What is wrong**: Only the automatic weather cycle runs off the GUI thread.
+  Everything else blocks the wx main loop. With `timeout=15` passed as a scalar,
+  each HTTP call can take up to 15 s to connect plus up to 15 s per socket read
+  (TLS handshake, headers, body), so the nominal worst case per call is about
+  30 s, more for a trickling response, plus an unbounded OS DNS lookup. While
+  blocked, no timers fire, no `CallAfter` results are delivered, no paint or
+  accessibility queries are answered.
+- **Failure scenario** (quantified):
+  - `File > Connect` with a SimBrief ID set: up to ~20 s before the Connect
+    dialog even appears (SimBrief fetch in the constructor), then up to ~30 s
+    after OK (ping). Same ~20 s stall opening the PDC dialog.
+  - Every poll tick: up to ~30 s, once every 20-75 s. A server that accepts
+    TCP but goes silent therefore freezes the UI for 15-30 s out of every
+    45-75 s; after three failures the same tick also runs
+    `attempt_reconnection()` (another ~30 s in one handler), then polling stops
+    with "Connection lost". Two to four minutes of mostly-frozen UI with no
+    announcement.
+  - A HANDOVER in a poll batch adds a synchronous logon send: poll + send up
+    to ~60 s in a single timer tick; a CONTACT in the same batch adds the
+    SimConnect setup (finding 5).
+  - Manual weather request up to ~30 s; manual update check up to ~10 s;
+    Exit while logged on: up to ~30 s after the confirm dialog is answered;
+    Disconnect while logged on: up to ~30 s plus the 500 ms `MilliSleep`.
+  - Accessibility impact: NVDA/JAWS query the window through UIA/MSAA; a
+    window that is not pumping messages times those calls out, so the user
+    hears nothing (or "not responding"), the status bar cannot be read, and
+    keystrokes typed during the freeze are queued and replayed afterwards,
+    landing on whatever dialog appears next.
+- **Evidence**:
+  ```python
+  # connection_manager.py:421-425 (weather); the hoppie_connector calls have the
+  # same 15 s applied by install_request_timeout()
+  def _fetch():
+      response = requests.get(api_url, params=params, timeout=NETWORK_TIMEOUT)
+  # polling_controller.py:149
+  messages, poll_status = self.connection_manager.poll()
+  # connect_dialog.py:62, executed inside wx.Dialog.__init__
+  ofp_data = get_latest_ofp(simbrief_userid)
+  ```
+- **Suggested fix direction**: Reuse the `WeatherMonitor` pattern (snapshot on
+  the GUI thread, worker thread, `wx.CallAfter` back) for poll, send, connect
+  and the SimBrief/update fetches; keep a single outstanding request per kind;
+  announce "Connecting..."/"Sending..." in the status bar before starting and
+  the outcome after. If that is too large a change, at minimum move the
+  SimBrief fetch out of the dialog constructors and split the timeout into a
+  short connect timeout and a total read budget.
+
+### 2. An exception in the message callback drops the rest of the poll batch
+
+- **Severity**: Medium. Messages already consumed from the server are lost for
+  good, including LOGON ACCEPTED / HANDOVER / LOGOFF that drive session state;
+  the guard exists precisely because callback failures are anticipated.
+- **Confidence**: Confirmed.
+- **Location(s)**: `src/controller/polling_controller.py:159-172`, `:197-198`;
+  `hoppie_connector/__init__.py:66-85` (`poll()` marks messages relayed).
+- **What is wrong**: `poll()` returns the whole batch and the server has already
+  marked every message relayed. The loop re-raises on the first failing
+  `message_callback(message)`, so messages 2..n are never logged (the
+  "Received message" log line is per iteration), never displayed, never
+  applied to `CpdlcSession`, and never considered by
+  `should_increase_polling_rate`. The `finally` keeps polling alive, but the
+  batch is gone.
+- **Failure scenario**: Batch `[uplink A, HANDOVER EDGG]`. Handling of A raises
+  (any exception escaping `_on_message_received`; today the concrete
+  candidates are the deliberately unconverted local `OSError`s from the
+  network layer during the nested logon, or a future bug in the SimConnect /
+  view path). The user sees the "Unexpected Error" dialog for A; the HANDOVER
+  is silently lost, the client still believes it is logged on to the old
+  station, and the next uplinks from EDGG are not answerable from the context
+  menu.
+- **Evidence**:
+  ```python
+  for message in messages:
+      self.logger.info(f"Received message: {message}")
+      if self.message_callback:
+          try:
+              self.message_callback(message)
+          except Exception:
+              self.logger.exception("Error in message callback")
+              raise
+  ```
+- **Suggested fix direction**: Keep the per-message `try`, but log and
+  continue with the remaining messages (and still apply
+  `should_increase_polling_rate`), then re-raise the first error (or report it
+  via the excepthook) after the loop; alternatively add the message to the
+  list before running the state/SimConnect logic so at least the text is shown.
+
+### 3. `UpdateChecker` can close the main window from under an open modal dialog, and its prompt can pop over any modal
+
+- **Severity**: Medium. Reachable in the very first run (welcome dialog ->
+  Settings dialog -> update prompt within seconds); the outcome is a
+  `RuntimeError` dialog at exit plus C++ undefined behaviour inside
+  `ShowModal()`.
+- **Confidence**: Plausible (every wx step verified in source; the end-to-end
+  sequence was not executed).
+- **Location(s)**: `src/utils/update_checker.py:42-49`, `:127-150`;
+  `src/gui/main_window.py:98-101` (auto check started in `__init__`),
+  `:1155-1158` (first launch schedules `on_settings` via `CallAfter`),
+  `:250-296` (`on_settings` `ShowModal`/`Destroy`), `:1072-1095` (`on_close`
+  ends with `event.Skip()` -> default handler -> `Destroy()`).
+- **What is wrong**: `_show_update_dialog` runs via `wx.CallAfter`, which the
+  main loop dispatches even while another dialog's modal loop is running. It
+  shows a parentless YES/NO box on top of whatever is open, and on YES posts
+  `self.parent.Close`. That `Close()` is also dispatched inside the open
+  dialog's modal loop: `on_close` runs, `Skip()` leads to
+  `wxTopLevelWindowBase::Destroy()` (deferred), and the deferred delete is
+  executed by `DeletePendingObjects()` in the *dialog's* loop at the next
+  idle. `~wxWindowMSW` -> `DestroyChildren()` deletes the modal dialog
+  immediately; `~wxDialog` -> `Show(false)` -> `ExitLoop()`; `ShowModal()` then
+  returns `GetReturnCode()` on a deleted object and the tied pointer writes
+  into freed memory. Back in Python, `on_settings` continues with
+  `dlg.Destroy()` (or `dlg.get_settings()`) on a dead proxy.
+- **Failure scenario**: First launch -> "set up now?" Yes -> Settings dialog
+  opens (CallAfter). ~1 s later the GitHub check finishes and "Update
+  Available" appears over the settings form (focus yanked away from the field
+  the user was editing). User answers Yes -> browser opens -> frame closes
+  under the Settings dialog -> `RuntimeError: wrapped C/C++ object of type
+  SettingsDialog has been deleted` -> "Unexpected Error" box -> app exits; the
+  log records an error and, in the worst case, the process crashes in the
+  freed-memory write.
+- **Evidence**:
+  ```python
+  # update_checker.py:147-150
+  webbrowser.open(release_url)
+  wx.CallAfter(self.parent.Close)
+  # main_window.py:259 / :296
+  if dlg.ShowModal() == wx.ID_OK:
+  ...
+  dlg.Destroy()
+  ```
+- **Suggested fix direction**: Do not close the application from the checker
+  (open the browser and leave the user in control), or have the main window
+  own the "update available" state and act on it only when no modal dialog is
+  active (e.g. check `wx.GetActiveWindow()`/a `_modal_depth` counter, or defer
+  until the pending `ShowModal()` returns). Give the prompt a parent and delay
+  it while a modal dialog is up.
+
+### 4. CPDLC session state survives disconnect and failed reconnection, and leaks into the next connection
+
+- **Severity**: Medium. After a reconnect the client can send requests to, and
+  offer responses for, a station it is not logged on to; `Logoff` cannot clear
+  the state while disconnected.
+- **Confidence**: Confirmed.
+- **Location(s)**: `src/model/cpdlc_session.py:108-141` (`logoff` only clears
+  `current_station` on a successful send), no reset method anywhere in the
+  class; `src/gui/main_window.py:349-402` (`on_disconnect` never resets the
+  session), `:316-347` (`on_connect` only sets the callsign);
+  `src/model/connection_manager.py:327-350` (failed `attempt_reconnection`
+  clears `cnx` only); `src/controller/polling_controller.py:182-196`.
+- **What is wrong**: `CpdlcSession.current_station`, `pending_logon_min`,
+  `pending_logon_station` and `cpdlc_min_counter` are never reset when the
+  network connection ends. `logoff()` returns `(False, None)` when the link is
+  already gone and leaves `current_station` set, so `is_logged_on()` stays
+  true through the disconnected period and into the next `connect()`, even
+  with a different callsign or the other network.
+- **Failure scenario**: (a) Logged on to LSAG; the link drops; three failed
+  polls trigger `attempt_reconnection()`, which fails and stops polling. The
+  user picks `File > Connect` (the label still reads "Disconnect", but the
+  handler routes to `on_connect` because `is_connected()` is false) and
+  connects as a new callsign. `is_logged_on()` is still true: the Requests
+  menu sends `REQUEST FL350` to LSAG without a logon, uplinks from LSAG are
+  answerable, the status bar and the exit confirmation talk about LSAG.
+  (b) Explicit Disconnect while the network is already down: the LOGOFF send
+  fails, `current_station` remains, and `Requests > Logoff` while offline
+  only reports "Failed to send logoff message", with no way to clear it.
+  Note: Hoppie logon state is kept by the ATC client keyed by callsign, so
+  keeping the station across a reconnect with the *same* callsign may be
+  intended; the different-callsign and unclearable cases are not.
+- **Evidence**:
+  ```python
+  # cpdlc_session.py:116-118
+  if not self.current_station or not self.connection_manager.is_connected():
+      return False, None      # current_station untouched
+  # main_window.py:389-394 -- no cpdlc_session reset
+  self.polling_controller.stop()
+  self.weather_monitor.stop()
+  self.weather_monitor.clear()
+  self.connection_manager.disconnect()
+  ```
+- **Suggested fix direction**: Add `CpdlcSession.reset()` and call it from
+  `on_disconnect`, after a failed reconnection, and from `connect()` when the
+  callsign/network changes; make `logoff()` clear local state even when the
+  send fails (report the send failure separately).
+
+### 5. SimConnect setup busy-waits on the GUI thread, a failed `send_event` is reported as success, and the retry path can orphan the dispatch thread
+
+- **Severity**: Medium. The busy-wait has no timeout and runs inside the poll
+  tick; the ignored return value defeats the "Auto-tune failed" status the
+  pilot relies on.
+- **Confidence**: Plausible for the hang (depends on simulator behaviour);
+  Confirmed for the ignored return value and the retry logic (from the
+  upstream source of Python-SimConnect and the manager code).
+- **Location(s)**: `src/utils/simconnect_manager.py:43-60` (`connect`),
+  `:74-111` (`set_com1_standby_mhz`), `:62-72` (`disconnect`);
+  `src/gui/main_window.py:1010-1027` (called from the poll tick).
+- **What is wrong**:
+  1. `SimConnect()` -> `connect()`: after a successful `SimConnect_Open` it
+     starts a daemon dispatch thread and spins `while self.ok is False: pass`
+     on the calling (GUI) thread until the `SIMCONNECT_RECV_ID_OPEN` message
+     arrives. Normally milliseconds, but there is no timeout: if the sim
+     accepts the pipe and delays the OPEN reply (e.g. while loading), the GUI
+     thread spins at 100% CPU for that long, in the middle of a poll tick.
+  2. `send_event()` returns `False` on failure; `set_com1_standby_mhz` ignores
+     the return value, logs "COM1 standby set" and returns `True`. If the sim
+     was closed after the first successful connect, `_sm` is kept and every
+     later CONTACT/MONITOR "succeeds" without tuning anything and without the
+     status-bar warning.
+  3. With the sim not running, `Open` fails silently (`ok` stays `False`, no
+     exception), `map_to_sim_event` returns `None`, so `connect()` returns
+     `True` with `_event_id = None`; `send_event(None, ...)` raises
+     `AttributeError`, the manager resets and retries: two full constructor
+     attempts per CONTACT/MONITOR message, all on the GUI thread.
+  4. On the exception path the manager sets `self._sm = None` without calling
+     `exit()`; if the dispatch thread had been started (Open succeeded, mapping
+     failed) it is orphaned and keeps calling `CallDispatch` every 2 ms for the
+     rest of the process.
+  5. Thread-safety of `_simconnect_available` / `_warned_unavailable`: only the
+     GUI thread touches them, so no race; the `_simconnect_available = None`
+     reset merely re-runs a cached import.
+- **Failure scenario**: CONTACT 121.800 arrives while MSFS is between flights;
+  the poll tick blocks in the spin loop until the sim answers; NVDA reports the
+  window as not responding. Separately: the sim is closed mid-flight, a later
+  CONTACT logs "COM1 standby set to ..." and the pilot, told nothing, expects
+  the standby frequency to be there.
+- **Evidence**:
+  ```python
+  # simconnect_manager.py:96-100 -- return value of send_event never checked
+  self._sm.send_event(self._event_id, freq_hz)
+  logger.info(f"COM1 standby set to {frequency_mhz:.3f} MHz ({freq_hz} Hz)")
+  return True
+  # simconnect_manager.py:101-109 -- _sm dropped without exit()
+  self._sm = None
+  self._event_id = None
+  ```
+  Upstream: `while self.ok is False: pass` in `SimConnect.connect()`;
+  `send_event` ends in `return False`; `map_to_sim_event` ends in
+  `return None`.
+- **Suggested fix direction**: Treat `_event_id is None` as a failed connect;
+  check `send_event()`'s return; call `_sm.exit()` before dropping it; perform
+  the SimConnect connect off the GUI thread (or once, at network connect time,
+  with a watchdog) and only `send_event` from the message path.
+
+### 6. Worker-thread liveness guards (`IsBeingDeleted()`) are ineffective and can raise; the exit-time error chain ends in an `AssertionError` inside `threading.excepthook`
+
+- **Severity**: Low. Only reachable while the application is exiting with a
+  fetch in flight; the effect is log noise and a dead worker, not user-visible
+  behaviour. Reported because the guard is relied on as the frame-destroyed
+  protection and it does not provide it.
+- **Confidence**: Confirmed mechanism (wx source: TLW `Destroy()` does not set
+  the flag; sip dead-proxy behaviour; `CallAfter` assertion); Plausible timing.
+- **Location(s)**: `src/model/weather_monitor.py:304`, `:310-311`;
+  `src/utils/update_checker.py:48`; `app.py:47-51`, `:59-60`.
+- **What is wrong**: For a top-level frame, `IsBeingDeleted()` becomes true
+  only inside the destructor (`~wxFrameBase`/`~wxWindowMSW`); the deferred
+  `Destroy()` from `on_close` does not set it. So on the worker thread the
+  check is either "alive -> False" or "already deleted -> `RuntimeError:
+  wrapped C/C++ object ... has been deleted`". It is also a wx call from a
+  non-GUI thread. In `_fetch_worker` the `RuntimeError` from `_post_result`
+  (outside the inner `try`) propagates, `finally` calls `_post_cycle_finished`,
+  which raises the same error; the thread dies, `threading.excepthook` ->
+  `report()` -> `wx.CallAfter(show_dialog, ...)`, and if the `wx.App` object
+  has already been collected `wx.CallAfter` raises
+  `AssertionError('No wx.App created yet')` inside the excepthook.
+  `_cycle_running` stays `True` (irrelevant at that point). The update
+  checker's copy of the check is inside a broad `except`, so it only logs
+  "Error checking for updates: wrapped C/C++ object ...".
+- **Failure scenario**: The user closes the window while a 5-subscription
+  cycle is mid-request. `MainLoop()` returns, `main()` logs "Application
+  shutdown complete", and before interpreter finalisation freezes daemon
+  threads the socket completes; the worker resumes, hits the dead proxy, and
+  the log ends with "Unhandled exception in background thread: RuntimeError:
+  wrapped C/C++ object of type MainWindow has been deleted" followed by an
+  "Exception in threading.excepthook" on a stderr that does not exist
+  (`console=False`).
+- **Evidence**:
+  ```python
+  # weather_monitor.py:304
+  if self._shutting_down or not self._parent or self._parent.IsBeingDeleted():
+  # weather_monitor.py:310
+  if not self._parent or self._parent.IsBeingDeleted():
+  # app.py:51 (worker path)
+  wx.CallAfter(show_dialog, text)
+  ```
+- **Suggested fix direction**: Never touch wx objects from the worker; have
+  `shutdown()` set a Python-side flag / `self._parent = None`, check only that
+  in the worker, wrap `wx.CallAfter` in `try/except (AssertionError,
+  RuntimeError)`, and re-check liveness inside the GUI-thread callbacks. In
+  `report()`, skip the dialog when `wx.GetApp() is None`.
+
+### 7. The exception reporter opens a modal dialog from inside the failing handler's dispatch, so timers keep running under it and repeated faults stack dialogs
+
+- **Severity**: Low. State machines survive it (verified), but a persistent
+  fault produces one new modal "Unexpected Error" box per poll tick (every
+  20-75 s), each of which a screen-reader user must dismiss.
+- **Confidence**: Confirmed mechanism (Phoenix thunker calls `PyErr_Print()`
+  synchronously).
+- **Location(s)**: `app.py:31-51`; `src/controller/polling_controller.py:147-198`.
+- **What is wrong**: When `on_poll_timer` (or a `CallAfter`'d weather callback)
+  raises, `sys.excepthook` -> `wx.MessageBox` runs while the timer event is
+  still being dispatched. The `finally` has already re-armed the one-shot, so
+  the next tick fires inside the dialog's modal loop and runs the whole poll
+  handler re-entrantly; if it raises again, a second dialog opens on top of
+  the first, and so on. Weather results, sounds and status-bar updates also
+  arrive while the error box is up.
+- **Failure scenario**: A fault that repeats on every tick (for example a
+  local `OSError` class the network layer deliberately does not convert,
+  raised from `attempt_reconnection()` at `:186`, which catches only
+  `HoppieError`): dialog at tick N, another at N+1 nested inside it, ... until
+  the user disconnects. Each dialog steals focus from the one before.
+- **Evidence**:
+  ```python
+  # app.py:47-48
+  if wx.IsMainThread():
+      show_dialog(text)          # synchronous modal, inside the failing handler
+  ```
+- **Suggested fix direction**: Coalesce reports (if a report dialog is
+  already open, log only or append to it) and show it via `wx.CallAfter` even
+  on the main thread so the failing handler unwinds first.
+
+### 8. `SimCpdlcApp.OnExceptionInMainLoop` is unreachable for Python errors and would itself raise `TypeError` when it does run
+
+- **Severity**: Low. Dead for the case it was written for; harmful only for a
+  genuine C++ exception, which wxPython almost never surfaces.
+- **Confidence**: Confirmed for the mechanism (thunker prints Python errors, so
+  no C++ exception; `sys.exc_info()` is `(None, None, None)` outside a Python
+  handler; `issubclass(None, KeyboardInterrupt)` raises `TypeError`, both
+  checked at runtime); Plausible for reachability.
+- **Location(s)**: `app.py:73-76`, `:53-57`.
+- **What is wrong**: Python exceptions from handlers are already reported via
+  `sys.excepthook` (called by `PyErr_Print()`); `OnExceptionInMainLoop` is only
+  invoked for a C++ exception escaping a handler. In that case
+  `sys.excepthook(*sys.exc_info())` calls `handle_uncaught(None, None, None)`,
+  which raises `TypeError: issubclass() arg 1 must be a class`; the original
+  problem is never logged and sip falls back to the default return value.
+- **Evidence**:
+  ```python
+  def OnExceptionInMainLoop(self):
+      sys.excepthook(*sys.exc_info())
+      return True
+  ```
+- **Suggested fix direction**: Guard on `exc_type is not None`; otherwise log a
+  generic "C++ exception in main loop" and return `True`. Or delete the
+  override and rely on the excepthook, which is the path that actually runs.
+
+### 9. Ctrl+C handling in `main()` is dead code: `wx.App` resets SIGINT to `SIG_DFL`, so an interrupt kills the process without any cleanup
+
+- **Severity**: Low. Only affects console runs (`python app.py`); the packaged
+  build has no console. Reported because the code claims to handle it.
+- **Confidence**: Confirmed (`wx/core.py:2143` default `clearSigInt=True`,
+  `:2188-2193`).
+- **Location(s)**: `app.py:69-71` (`super().__init__(False)` leaves
+  `clearSigInt=True`), `:100-105`, `:53-56`.
+- **What is wrong**: With `SIG_DFL` installed, Ctrl+C terminates the process
+  immediately: no `KeyboardInterrupt`, no `frame.on_exit(None)`, no LOGOFF, no
+  "Application shutdown complete" log line, and the `finally` never runs. Even
+  if the branch were reached, `frame.on_exit(None)` after `MainLoop()` has
+  returned would run `on_close` synchronously and queue a `Destroy()` that no
+  loop ever processes (and raise `RuntimeError` if the frame was the reason
+  the loop ended).
+- **Evidence**:
+  ```python
+  try:
+      app.MainLoop()
+  except KeyboardInterrupt:
+      logger.info("Application terminated by keyboard interrupt")
+      frame.on_exit(None)
+  ```
+- **Suggested fix direction**: Either pass `clearSigInt=False` and handle
+  SIGINT deliberately (a short `wx.Timer` lets Python deliver the signal, then
+  call `frame.Close()`), or remove the dead branch.
+
+### 10. `dlg.Destroy()` is not reached when anything raises between `ShowModal()` and the end of the handler
+
+- **Severity**: Low. Leaks a hidden dialog per failure and skips the trailing
+  UI updates; the exception itself is already reported.
+- **Confidence**: Confirmed.
+- **Location(s)**: `src/gui/main_window.py:259-296` (settings), `:320-347`
+  (connect), `:417-449` (logon; the early `dlg.Destroy(); return` at `:427-428`
+  is correct), `:513-533`, `:554-570`, `:591-609`, `:630-646`, `:673-690`,
+  `:720-754`, `:810-840`.
+- **What is wrong**: None of the `ShowModal()` ... `Destroy()` sequences uses
+  `try/finally` or `with dlg:`. Normal branches all reach `Destroy()`.
+  Exceptions that can occur in between are exactly the ones the network layer
+  chooses not to convert to `HoppieError` (local `OSError`s such as the
+  missing CA bundle case pinned by
+  `test_a_local_os_error_is_not_disguised_as_a_network_failure`), since
+  `CpdlcSession` catches only `HoppieError`, plus any wx error in
+  `_add_custom_message`.
+- **Failure scenario**: `on_connect` -> `connect()` raises `OSError` -> the
+  excepthook dialog appears, the Connect dialog object stays alive (hidden) as
+  a child TLW until the frame closes; repeated attempts accumulate them.
+- **Evidence**:
+  ```python
+  dlg = ConnectDialog(self)
+  if dlg.ShowModal() == wx.ID_OK:
+      ...
+      self.connection_manager.connect(callsign, logon_code, network_type)  # may raise non-HoppieError
+  ...
+  dlg.Destroy()
+  ```
+- **Suggested fix direction**: `with SettingsDialog(...) as dlg:` (wxPython
+  dialogs support the context-manager protocol and call `Destroy()`), or
+  `try/finally`.
+
+### 11. A weather cycle in flight survives disconnect/reconnect and resumes under the new session's identity; the credential snapshot it takes is not atomic
+
+- **Severity**: Low. Wastes requests and, in a microsecond window, can pair one
+  network's URL with the other network's logon code; no state corruption on the
+  GUI side.
+- **Confidence**: Confirmed.
+- **Location(s)**: `src/model/weather_monitor.py:107` (`start()` clears
+  `_shutting_down`), `:120-125`, `:218-224`, `:262-269`, `:278-298`;
+  `src/model/connection_manager.py:246-251`, `:264-270` (fields written one at
+  a time), `:408-418` (fields read one at a time on the worker).
+- **What is wrong**: `stop()` only sets a flag the worker samples once per
+  subscription (before a 1 s sleep and a request of up to ~30 s). If the user
+  disconnects and reconnects inside that window, `start()` has already cleared
+  `_shutting_down`, so the worker never notices: it finishes the *old*
+  subscription list using whatever `cnx`/`network_type`/`logon_code`/`callsign`
+  are current, and posts results that `_on_result` drops (`:328-331`) unless the
+  same key was re-subscribed. Independently, the worker reads the four
+  attributes in sequence while `connect()`/`disconnect()` write them in
+  sequence on the GUI thread; a GIL switch between the reads yields a mixed
+  snapshot (SayIntentions URL + Hoppie logon, or an empty `from=`/`logon=`),
+  i.e. one malformed request or one credential sent to the other network's
+  server. The counters are safe: the worker touches only `info_failures`,
+  which gates nothing; `cnx` is swapped by a single attribute assignment and
+  never dereferenced across threads.
+- **Failure scenario**: Ten subscriptions; the user disconnects from Hoppie and
+  connects to SayIntentions within a few seconds. Up to nine more `inforeq`
+  GETs go to SayIntentions for the Hoppie-era airports under the new
+  credentials, then results are discarded; meanwhile new ticks are skipped
+  because `_cycle_running` is still `True`.
+- **Evidence**:
+  ```python
+  # weather_monitor.py:278-283
+  for index, (icao, info_type) in enumerate(pending):
+      if self._shutting_down:
+          break
+      if index:
+          time.sleep(_REQUEST_SPACING_SECONDS)
+  # connection_manager.py:411-414 (worker thread)
+  api_url = self._api_url()
+  params = {"logon": self.logon_code, "from": self.callsign, ...}
+  ```
+- **Suggested fix direction**: Give each cycle a generation number captured
+  in `_run_cycle` and checked in `_post_result`/`_on_result`; snapshot the
+  credentials on the GUI thread in `_run_cycle` and pass them into the worker
+  (e.g. a `send_info_request(info_type, icao, credentials)` overload).
+
+### 12. No overall deadline for a weather cycle: a single stuck request keeps `_cycle_running` true for the rest of the session
+
+- **Severity**: Low. Automatic updates silently stop and "Check now" keeps
+  saying a check is already running; no other damage.
+- **Confidence**: Confirmed (design gap; timeout semantics verified).
+- **Location(s)**: `src/model/weather_monitor.py:253-255`, `:264-269`,
+  `:299-317`; `src/model/connection_manager.py:423`.
+- **What is wrong**: Per request the bound is 15 s connect + 15 s per socket
+  read (not total) + unbounded DNS; per cycle it is that times the number of
+  subscriptions, plus 1 s spacing, sequentially. Ten subscriptions can exceed
+  the default 5-minute interval on a slow link, so alternate ticks are skipped
+  and the effective interval doubles. A trickling response or a hung resolver
+  has no upper bound at all, and nothing ever clears `_cycle_running` except
+  the worker itself.
+- **Evidence**:
+  ```python
+  if self._cycle_running:
+      self.logger.debug("Weather update cycle still running, skipping this tick")
+      return False
+  ```
+- **Suggested fix direction**: Per-cycle budget (e.g. the interval itself) and
+  a generation counter so the timer can abandon a late cycle and start a new
+  one; optionally fetch subscriptions concurrently with a small pool.
+
+### 13. `on_disconnect` sleeps 500 ms on the GUI thread for no effect and re-arms polling immediately before stopping it
+
+- **Severity**: Low. A half-second freeze and two pointless timer operations.
+- **Confidence**: Confirmed.
+- **Location(s)**: `src/gui/main_window.py:379-391`.
+- **What is wrong**: `send_logoff_message()` is synchronous; when it returns the
+  HTTP request has completed, so the "small delay to allow the message to be
+  sent" achieves nothing except blocking the loop (no timers, no `CallAfter`
+  deliveries run inside `wx.MilliSleep`). `polling_controller.set_active_polling()`
+  at `:383` does `Stop()` + `StartOnce(20000)` three lines before `stop()`.
+- **Evidence**:
+  ```python
+  self.polling_controller.set_active_polling()
+  # Small delay to allow the message to be sent
+  wx.MilliSleep(500)  # 500ms delay
+  # Stop polling and automatic weather updates
+  self.polling_controller.stop()
+  ```
+- **Suggested fix direction**: Delete both lines.
+
+### 14. (Info) `_check_first_launch` runs a modal loop in the middle of `__init__`, before `_init_ui`, before `EVT_CLOSE` is bound, and before the controllers exist
+
+- **Severity**: Info. Safe today; fragile.
+- **Confidence**: Confirmed.
+- **Location(s)**: `src/gui/main_window.py:79`, `:1142-1153`, `:126`.
+- **What is wrong / why it is fine now**: The welcome `wx.MessageDialog` is
+  shown while the frame has no panel, no message view, no `weather_monitor`,
+  no `polling_controller`, no `update_checker` and no close handler. Nothing
+  else can run in that nested loop today (no timers, no threads, no pending
+  `CallAfter`), and the follow-up `on_settings` is correctly deferred with
+  `wx.CallAfter`, so `self.weather_monitor` exists by the time it runs
+  (created at `:117`, before `Show()` and before the main loop starts). A
+  forced close during the welcome dialog would bypass `on_close`. Prefer
+  scheduling the whole first-launch prompt with `wx.CallAfter` after
+  construction.
+
+### 15. (Info) `WeatherSubscriptionsDialog` can show stale entries while open
+
+- **Severity**: Info. No crash.
+- **Confidence**: Confirmed.
+- **Location(s)**: `src/gui/dialogs/weather_subscriptions_dialog.py:94-104`,
+  `:131-139`; `src/model/weather_monitor.py:339-345`.
+- **What is wrong**: `CallAfter`'d `_on_result` callbacks run during the
+  dialog's modal loop, so a subscription can be dropped for
+  `MAX_CONSECUTIVE_ERRORS` while it is listed. `_keys` is not refreshed, so
+  "Stop updating" on that row unsubscribes a key that is already gone
+  (returns `False`) and the following `_refresh()` corrects the list. A
+  refresh hook from `on_error`/`on_update` would keep the list honest.
+
+### 16. (Info) A non-vetoable close still shows the confirm dialog and calls `Veto()`
+
+- **Severity**: Info. Only on `Close(force=True)` paths such as a Windows
+  end-session.
+- **Confidence**: Confirmed for the code; the wx assertion behaviour is
+  standard (`wxCloseEvent::Veto` is a `wxCHECK_RET`).
+- **Location(s)**: `src/gui/main_window.py:1077-1079`, `:1111-1121`.
+- **What is wrong**: `_confirm_exit` does not check `event.CanVeto()`. On a
+  forced close it still blocks in a MessageBox and, on "No", calls `Veto()`,
+  which trips a wx assertion (raised as `wx.wxAssertionError` under
+  wxPython's default assert mode); `shutdown()` and `Skip()` are then skipped.
+  Check `CanVeto()` and go straight to cleanup when it is false.
+
+---
+
+## Things I checked that are fine
+
+- **WeatherMonitor ownership model.** All subscription mutation
+  (`subscribe`/`unsubscribe`/`clear`/`_on_result`) is on the GUI thread; the
+  worker receives a list of `(icao, info_type)` tuples, never the dict; results
+  come back through `wx.CallAfter` in FIFO order with `_on_cycle_finished`
+  posted last, so `_cycle_running` is cleared only after every result of that
+  cycle has been applied; `_on_result` tolerates unsubscribe/clear/re-subscribe
+  while a request was in flight (`weather_monitor.py:328-331`);
+  `_cycle_running` is written on the GUI thread except in the dead-frame path
+  of finding 6.
+- **Timer lifecycle across start/stop/shutdown/start.** `wx.Timer.Destroy()`
+  exists; `shutdown()` stops, destroys and nulls the timer, and the next
+  `start()` creates a fresh timer and binding on the same parent; `stop()` and
+  `start()` are idempotent; `set_interval()` while stopped only stores the
+  value that the next `start()` uses; `check_now()` while stopped or
+  disconnected returns `False` (covered by `test_weather_monitor.py`).
+  `shutdown()` is only called from `on_close`, so the never-unbound old
+  `EVT_TIMER` entry cannot accumulate.
+- **Weather timer re-entrancy.** It is a continuous timer whose handler only
+  snapshots and spawns; a tick inside a nested modal loop is harmless.
+- **PollingController one-shot state machine.** wxMSW stops a one-shot timer
+  before `Notify()`, so `is_running()` is false inside the tick and the
+  `set_active_polling()` guard behaves as the test
+  `test_a_message_that_speeds_up_polling_mid_tick_still_schedules_once`
+  describes; there is a single `wx.Timer`, and `StartOnce` on it restarts it,
+  so there can never be two pending polls; every exit from `on_poll_timer`
+  either reaches the `finally` reschedule or deliberately called `stop()`
+  first; a WM_TIMER already queued when `stop()` runs is discarded by the MSW
+  timer map; `stop()` followed by `start()` reuses the bound timer correctly
+  (`_stopped` cleared, `_schedule_next()` re-arms); `_next_poll_at` is only
+  read/written on the GUI thread; ticks cannot overlap because the handler
+  contains no modal dialog (the only modal that can nest inside a tick is the
+  excepthook's, finding 7).
+- **Modal dialogs inside the timer handler.** `_on_message_received` shows no
+  dialogs; `wx.MessageBox` appears only in menu handlers, in
+  `_on_acknowledge_message` (PopupMenu context), and in the excepthook.
+- **message_view.py context menus.** Bindings are per-item-id on the panel,
+  the panel is the `PopupMenu` target, wxMSW dispatches the resulting
+  WM_COMMAND before `PopupMenu()` returns, and `Unbind(wx.EVT_MENU, id=...)`
+  matches the real `EvtHandler.Unbind(event, source=None, id=..., id2=...,
+  handler=None)` signature, so the handler always runs before the unbind and
+  no binding accumulates (TODO #2 is fixed). Lambda defaults (`resp=`, `mid=`,
+  `r=`) avoid late binding. `PopupMenu` cannot be re-entered: the list is
+  disabled while any modal opened by the handler is up. A handler exception is
+  swallowed by the thunker, so `Unbind`/`menu.Destroy()` still run.
+  `wx.ID_ANY` menu-item ids are unique among live items.
+- **Construction order vs. `CallAfter`.** `on_settings` scheduled from
+  `_check_first_launch` runs after `__init__` completes; every attribute it
+  uses (`weather_monitor`) exists by then. The update-check thread started at
+  `main_window.py:101` touches only `self.parent` and `wx.CallAfter`, and its
+  `CallAfter`'d dialog cannot run before the main loop starts.
+- **`on_close` sequence.** Polling stopped (whenever connected), weather timer
+  destroyed before the frame, SimConnect `exit()` joins its 2 ms loop quickly,
+  then `Skip()`. The poll timer is always stopped whenever `is_connected()`
+  becomes false (`on_disconnect`, failed `attempt_reconnection`, the
+  not-connected branch of the tick), so no running timer can outlive its owner
+  frame. Anything still queued afterwards is harmless on the GUI thread:
+  `_on_result` is not posted once `_shutting_down` is set,
+  `_on_cycle_finished` is pure Python, and `event.Skip()`/`Veto()` are paired
+  correctly on every normal path.
+- **SimConnectManager flags.** `_simconnect_available` and
+  `_warned_unavailable` are touched only from the GUI thread (message path
+  and `on_close`); Python-SimConnect's dispatch thread never reaches them.
+- **`wx.adv.Sound`.** Loaded once in `__init__`; `Play(SOUND_ASYNC)` is
+  non-blocking; `if self.new_message_sound:` uses `Sound.__bool__` ->
+  `IsOk()`, so a file that exists but fails to load is skipped; only called on
+  the GUI thread (`_on_message_received` from the timer, `_on_weather_update`
+  via `CallAfter`).
+- **`wx.CallAfter` first-use race.** The lazy `_CallAfterId` initialisation
+  is not locked, but the first call is on the GUI thread (first launch) or the
+  update thread seconds after start, long before the weather worker exists,
+  and a double initialisation would still dispatch correctly.
+- **`install_request_timeout`.** It rebinds `requests.get`/`requests.post`,
+  which `hoppie_connector/API.py:39,44` looks up at call time, so every
+  connector call gets the 15 s default; the three app-owned request sites pass
+  explicit timeouts.
+- **ConnectionManager cross-thread counters.** The worker writes only
+  `info_failures`, which is excluded from `failure_count()` and therefore
+  from reconnection decisions (spec fix 6, verified); `connection_failures`,
+  `send_failures` and the connector object are GUI-thread only.
+- **Logging and excepthooks.** Handlers are thread-safe; both hooks are
+  installed before any thread or `wx.App` exists; `report()` correctly routes
+  worker-thread reports through `wx.CallAfter` (modulo finding 6).
+- **hoppie_connector usage.** `HoppieConnector.__init__` performs no I/O;
+  `ping`, `poll`, `send_cpdlc` (GET) and `send_telex` (POST) are one request
+  each; `_call` converts `ValueError`/`TypeError`/`ConnectionError`/
+  `RequestException` to `HoppieError` for every path the worker uses, so the
+  weather thread's `except HoppieError` covers the library's failure modes.

--- a/docs/superpowers/plans/2026-09-03-pkg1-test-harness.md
+++ b/docs/superpowers/plans/2026-09-03-pkg1-test-harness.md
@@ -1,0 +1,1694 @@
+# Package 1: Test Harness Hermeticity and Protocol Regression Tests — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the test suite unable to touch the developer's real configuration, the network, SimBrief, SimConnect or a modal dialog, and pin the CPDLC protocol behaviour that later packages must not break.
+
+**Architecture:** Helpers and test doubles move from `tests/conftest.py` into a plain module `tests/support.py`; `conftest.py` keeps fixtures only and gains four autouse fixtures (`isolated_config`, `no_network`, `no_simbrief`, `message_boxes`) plus a leaked-window assertion in `wx_app`. New regression tests assert the literal wire frames, the MRN validation, the response table, every message-handling branch of `MainWindow._on_message_received`, the menu and context-menu bindings, the config file round trip and the two parsers. No production code under `src/` changes in this package.
+
+**Tech Stack:** Python 3.12+, pytest 9.1.1, pytest-timeout, wxPython 4.2.5, hoppie-connector 0.2.1.
+
+## Global Constraints
+
+- Run every command with the only interpreter that has the dependencies: `C:\Claude\sim-cpdlc\.claude\worktrees\review-25-ceb148\.venv\Scripts\python.exe` (below written as `$PY`). It works from any working directory, including a fresh git worktree. In Git Bash: `PY=/c/Claude/sim-cpdlc/.claude/worktrees/review-25-ceb148/.venv/Scripts/python.exe`.
+- Run the suite from the repository root as `$PY -m pytest -q -p no:cacheprovider`. It must be green at the end of every task. Baseline before this plan: 135 passed.
+- Tests must never read or write the real config file (`%LOCALAPPDATA%\Sim-CPDLC\Sim-CPDLC\config.json`), reach the network, call SimBrief, touch the simulator, or block on a dialog.
+- This package changes only `tests/`, `requirements-dev.txt`, `pytest.ini`, `.github/workflows/tests.yml` and `tests/README.md`. Do not edit anything under `src/`. Where a step says "mutation check", the temporary edit to `src/` is reverted with `git checkout -- <file>` in the same step.
+- Import helpers as `from tests.support import ...` (the repo root is on `sys.path` via `pythonpath = .` in `pytest.ini`; `tests/` has no `__init__.py` and needs none).
+- Commit messages: imperative sentence subject, optional body, and end with the trailer `Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>`. Git prints CRLF warnings on this machine; they are harmless.
+- Spec: `docs/superpowers/specs/2026-09-03-audit-fixes-design.md`, section "Package 1". Audit: `docs/audit/2026-09-03-codebase-audit.md` (M-11, M-12, L-21).
+
+---
+
+## File structure
+
+| File | Responsibility after this plan |
+|---|---|
+| `tests/support.py` (new) | Test doubles and builders: `uplink`, `FakeConnectionManager`, `RecordingMessageView`, `FakePollingController`, `FakeSimConnectManager`, `make_main_window`. No fixtures. |
+| `tests/conftest.py` (rewrite) | Fixtures only: `logger`, `isolated_config`, `no_network`, `no_simbrief`, `message_boxes`, `wx_app` (with leak assertion), `frame`. |
+| `tests/test_harness.py` (new) | Proves the hermetic fixtures do what they claim. |
+| `tests/test_uplink_handling.py` (new) | `MainWindow._on_message_received` branches: HANDOVER, LOGOFF, protocol-noise filter, CONTACT auto-tune. |
+| `tests/test_frequency_parser.py` (new) | Table test for `extract_contact_frequency`. |
+| `tests/test_message_formatting.py` (new) | Table tests for `extract_message_content`, `format_list_text`, `format_message_text`. |
+| `tests/test_acknowledge_path.py`, `test_connection_manager.py`, `test_cpdlc_session.py`, `test_logon_status.py`, `test_message_manager.py`, `test_downlink_requests.py`, `test_main_window.py`, `test_message_view.py`, `test_config.py` | Existing files gain the regression tests listed per task; imports switch to `tests.support`. |
+| `requirements-dev.txt`, `pytest.ini`, `.github/workflows/tests.yml` | pytest-timeout and CI job timeout. |
+| `tests/README.md` | Regenerated table. |
+
+---
+
+### Task 1: Move the shared helpers into `tests/support.py`
+
+**Files:**
+- Create: `tests/support.py`
+- Modify: `tests/conftest.py:1-115` (remove everything except the `logger`, `wx_app`, `frame` fixtures)
+- Modify (imports only): `tests/test_acknowledge_path.py:3`, `tests/test_cpdlc_session.py:3`, `tests/test_downlink_requests.py:10`, `tests/test_logon_status.py:8`, `tests/test_main_window_wiring.py:12`, `tests/test_message_manager.py:3`, `tests/test_message_view.py:6`, `tests/test_polling_controller.py:7`
+
+**Interfaces:**
+- Produces (used by every later task):
+  - `uplink(sender, min_value, text="CLIMB TO AND MAINTAIN FL360", rr=RR.WILCO_UNABLE, mrn=None) -> CpdlcMessage`
+  - `FakeConnectionManager(connected=True, raise_with=None)` with `.sent` (list of `(recipient, min, rr, text, mrn)`), `.telexes` (list of `(recipient, text)`), `.info_requests`, `is_connected()`, `send_cpdlc(...)`, `send_telex(recipient, message)`, `send_info_request(info_type, icao)`
+  - `FakeSimConnectManager(result=True)` with `.tuned` (list of floats), `.result`, `connect()`, `disconnect()`, `set_com1_standby_mhz(frequency_mhz) -> bool`
+  - `RecordingMessageView` with `.added`; `FakePollingController` with `.active_calls`
+  - `make_main_window(logger, cpdlc_session, message_manager, config=None, simconnect=None) -> MainWindow` (window has `.status_texts`, `.message_view.added`, `.polling_controller.active_calls`, `.simconnect_manager`)
+  - `CLIENT_CALLSIGN = "DLH123"`
+
+- [ ] **Step 1: Create `tests/support.py`**
+
+```python
+"""Shared test doubles and builders for the sim-cpdlc test suite.
+
+These are helpers, not fixtures: import them explicitly with
+`from tests.support import ...`. Fixtures live in conftest.py.
+"""
+
+from hoppie_connector import CpdlcMessage, CpdlcResponseRequirement as RR
+
+from src.config import DEFAULT_CONFIG, save_config
+
+CLIENT_CALLSIGN = "DLH123"
+
+
+def uplink(
+    sender, min_value, text="CLIMB TO AND MAINTAIN FL360", rr=RR.WILCO_UNABLE, mrn=None
+):
+    """Build an uplink CpdlcMessage as it would arrive from a station.
+
+    Args:
+        sender: Station sending the message
+        min_value: The station's own message number (MIN)
+        text: Message element text
+        rr: Response requirement
+        mrn: Message reference number, the MIN of our message this one
+            answers. Every real LOGON ACCEPTED carries one.
+    """
+    return CpdlcMessage(sender, CLIENT_CALLSIGN, min_value, rr, text, mrn)
+
+
+class FakeConnectionManager:
+    """Stands in for ConnectionManager, recording frames instead of transmitting.
+
+    ConnectionManager is the network boundary and is injected into CpdlcSession,
+    so this is the intended seam rather than a mock of code under test.
+
+    Args:
+        connected: What is_connected() reports
+        raise_with: An exception every send raises instead of recording, for
+            exercising the failure paths
+    """
+
+    def __init__(self, connected=True, raise_with=None):
+        self._connected = connected
+        self.raise_with = raise_with
+        self.sent = []
+        self.telexes = []
+        self.info_requests = []
+
+    def is_connected(self):
+        return self._connected
+
+    def send_cpdlc(self, recipient, min_value, response_type, message, mrn=None):
+        if self.raise_with is not None:
+            raise self.raise_with
+        self.sent.append((recipient, min_value, response_type, message, mrn))
+
+    def send_telex(self, recipient, message):
+        if self.raise_with is not None:
+            raise self.raise_with
+        self.telexes.append((recipient, message))
+
+    def send_info_request(self, info_type, icao):
+        if self.raise_with is not None:
+            raise self.raise_with
+        self.info_requests.append((info_type, icao))
+        return f"{icao} REPORT FOR {info_type}"
+
+
+class RecordingMessageView:
+    """Captures the message IDs the window pushes into the list view."""
+
+    def __init__(self):
+        self.added = []
+
+    def add_message(self, message_id):
+        self.added.append(message_id)
+
+
+class FakePollingController:
+    """Records polling-rate changes without owning a wx.Timer."""
+
+    def __init__(self):
+        self.active_calls = 0
+
+    def set_active_polling(self):
+        self.active_calls += 1
+
+
+class FakeSimConnectManager:
+    """Records the frequencies the window tries to tune, never touching a simulator.
+
+    Args:
+        result: What connect() and set_com1_standby_mhz() report back
+    """
+
+    def __init__(self, result=True):
+        self.result = result
+        self.tuned = []
+
+    def connect(self):
+        return self.result
+
+    def disconnect(self):
+        pass
+
+    def set_com1_standby_mhz(self, frequency_mhz):
+        self.tuned.append(frequency_mhz)
+        return self.result
+
+
+def make_main_window(logger, cpdlc_session, message_manager, config=None, simconnect=None):
+    """Build a MainWindow whose wx.Frame half is never initialised.
+
+    MainWindow.__init__ opens dialogs, loads sounds and starts an update check,
+    none of which a unit test should trigger. Allocating the instance and wiring
+    only the collaborators the message path touches lets the real
+    _on_message_received / _on_acknowledge_message code run unmodified.
+
+    Args:
+        logger: Test logger
+        cpdlc_session: The CpdlcSession the window should drive
+        message_manager: The MessageManager the window should fill
+        config: Overrides written to the (isolated) config file, so the
+            window's own load_config() calls see them. None leaves the
+            defaults in place.
+        simconnect: A FakeSimConnectManager; a fresh one when None
+    """
+    from src.gui.main_window import MainWindow
+
+    if config is not None:
+        assert save_config({**DEFAULT_CONFIG, **config}), "could not write test config"
+
+    window = MainWindow.__new__(MainWindow)
+    window.logger = logger
+    window.cpdlc_session = cpdlc_session
+    window.message_manager = message_manager
+    window.message_view = RecordingMessageView()
+    window.polling_controller = FakePollingController()
+    window.simconnect_manager = (
+        simconnect if simconnect is not None else FakeSimConnectManager()
+    )
+    window.new_message_sound = None
+    window.status_texts = []
+    # Instance attribute shadows wx.Frame.SetStatusText, which would need a
+    # live C++ frame behind it.
+    window.SetStatusText = window.status_texts.append
+    return window
+```
+
+- [ ] **Step 2: Cut `tests/conftest.py` down to fixtures**
+
+Replace the whole file with:
+
+```python
+"""Shared fixtures for the sim-cpdlc test suite.
+
+Helpers and test doubles live in tests/support.py; this file holds fixtures
+only.
+"""
+
+import logging
+
+import pytest
+import wx
+
+
+@pytest.fixture
+def logger():
+    """A real logger that discards output, so log calls are exercised but silent."""
+    log = logging.getLogger("sim-cpdlc-tests")
+    log.handlers = [logging.NullHandler()]
+    log.propagate = False
+    return log
+
+
+@pytest.fixture
+def wx_app():
+    """A wx application context.
+
+    Torn down rather than shared, because wx allows only one live App at a
+    time and a leaked one would break whichever test ran next.
+    """
+    app = wx.App()
+    yield app
+    # Destroy() only queues a window for deletion; without a yield the whole
+    # object graph behind it -- and for a MainWindow that means a weather
+    # monitor, a SimConnect manager and an update checker -- stays alive for
+    # the rest of the session.
+    wx.SafeYield()
+    app.Destroy()
+
+
+@pytest.fixture
+def frame(wx_app):
+    """A top-level window to parent dialogs and timers onto."""
+    frame = wx.Frame(None)
+    yield frame
+    frame.Destroy()
+```
+
+- [ ] **Step 3: Switch the eight import lines**
+
+In each file replace the `from conftest import ...` line with the same names from `tests.support`:
+
+```python
+# tests/test_acknowledge_path.py
+from tests.support import FakeConnectionManager, make_main_window, uplink
+# tests/test_cpdlc_session.py
+from tests.support import FakeConnectionManager
+# tests/test_downlink_requests.py
+from tests.support import FakeConnectionManager
+# tests/test_logon_status.py
+from tests.support import FakeConnectionManager, make_main_window, uplink
+# tests/test_main_window_wiring.py
+from tests.support import FakeConnectionManager, uplink
+# tests/test_message_manager.py
+from tests.support import uplink
+# tests/test_message_view.py
+from tests.support import uplink
+# tests/test_polling_controller.py
+from tests.support import FakeConnectionManager, uplink
+```
+
+- [ ] **Step 4: Run the suite and confirm nothing imports `conftest` any more**
+
+Run: `$PY -m pytest -q -p no:cacheprovider`
+Expected: `135 passed`
+
+Run: `grep -rn "from conftest" tests`
+Expected: no output
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/support.py tests/conftest.py tests/test_acknowledge_path.py tests/test_cpdlc_session.py tests/test_downlink_requests.py tests/test_logon_status.py tests/test_main_window_wiring.py tests/test_message_manager.py tests/test_message_view.py tests/test_polling_controller.py
+git commit -m "Move the test doubles out of conftest into tests/support.py
+
+conftest.py is for fixtures; importing helpers from it only works under
+pytest's default import mode. The doubles also grow what later tests need:
+uplink() takes an MRN, FakeConnectionManager can raise on send and records
+telexes, and make_main_window wires a fake SimConnect manager and an
+optional config.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Hermetic autouse fixtures
+
+**Files:**
+- Create: `tests/test_harness.py`
+- Modify: `tests/conftest.py` (add fixtures, leak assertion)
+- Modify: `tests/test_main_window.py:43-71` (the `window` fixture)
+
+**Interfaces:**
+- Consumes: `tests.support` from Task 1.
+- Produces (fixtures available to every test):
+  - `isolated_config` (autouse) -> `str` path of the per-test config file; `src.config.CONFIG_FILE` points at it
+  - `no_network` (autouse): `requests.get`, `requests.post`, `webbrowser.open` raise `RuntimeError("network access in a test")`
+  - `no_simbrief` (autouse) -> `list` of SimBrief user ids the dialogs asked for; lookups return `None`
+  - `message_boxes` (autouse) -> recorder with `.calls` (list of `(message, caption, style)`), `.captions`, `.answer` (default `wx.YES`)
+  - `build_window()` factory fixture in `tests/test_main_window.py` returning a real, hidden `MainWindow`; `window` fixture built from it
+
+- [ ] **Step 1: Write the failing harness tests**
+
+Create `tests/test_harness.py`:
+
+```python
+"""The hermetic fixtures: nothing a test builds may reach outside the test.
+
+Every fixture checked here is autouse, so these tests document guarantees the
+whole suite relies on.
+"""
+
+import webbrowser
+from pathlib import Path
+
+import pytest
+import requests
+import wx
+
+from src import config as config_module
+from src.config import DEFAULT_CONFIG, load_config, save_config
+from src.gui.dialogs import ConnectDialog
+
+
+def test_the_config_file_is_a_temporary_one(isolated_config, tmp_path):
+    assert Path(config_module.CONFIG_FILE) == tmp_path / "config.json"
+    assert Path(isolated_config) == tmp_path / "config.json"
+
+
+def test_saving_the_config_writes_only_the_temporary_file(isolated_config):
+    assert save_config({**DEFAULT_CONFIG, "simbrief_userid": "42"}) is True
+
+    assert Path(isolated_config).exists()
+    assert load_config()["simbrief_userid"] == "42"
+
+
+def test_network_access_is_refused():
+    with pytest.raises(RuntimeError, match="network access in a test"):
+        requests.get("https://example.invalid/")
+    with pytest.raises(RuntimeError, match="network access in a test"):
+        requests.post("https://example.invalid/")
+
+
+def test_opening_a_browser_is_refused():
+    with pytest.raises(RuntimeError, match="network access in a test"):
+        webbrowser.open("https://example.invalid/")
+
+
+def test_message_boxes_are_recorded_and_answered_without_showing(message_boxes):
+    message_boxes.answer = wx.NO
+
+    assert wx.MessageBox("Sure?", "Confirm", wx.YES_NO) == wx.NO
+    assert message_boxes.calls == [("Sure?", "Confirm", wx.YES_NO)]
+    assert message_boxes.captions == ["Confirm"]
+
+
+def test_the_connect_dialog_never_reaches_simbrief(frame, no_simbrief, message_boxes):
+    """With a SimBrief id configured the dialog fetches the flight plan in its
+    constructor and warns when that fails; both must stay inside the test."""
+    save_config({**DEFAULT_CONFIG, "simbrief_userid": "189007"})
+
+    dialog = ConnectDialog(frame)
+    try:
+        assert no_simbrief == ["189007"]
+        assert message_boxes.captions == ["SimBrief"]
+    finally:
+        dialog.Destroy()
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `$PY -m pytest tests/test_harness.py -q -p no:cacheprovider`
+Expected: errors of the form `fixture 'isolated_config' not found` / `fixture 'message_boxes' not found` / `fixture 'no_simbrief' not found`, and `test_network_access_is_refused` failing because a real `requests.ConnectionError` (not `RuntimeError`) is raised.
+
+- [ ] **Step 3: Add the fixtures to `tests/conftest.py`**
+
+Replace the file with:
+
+```python
+"""Shared fixtures for the sim-cpdlc test suite.
+
+Helpers and test doubles live in tests/support.py; this file holds fixtures
+only. The autouse fixtures make the suite hermetic: whatever a test builds, it
+cannot read or write the real configuration file, reach the network, call
+SimBrief or block on a message box.
+"""
+
+import logging
+import webbrowser
+
+import pytest
+import requests
+import wx
+
+from src import config as config_module
+
+
+@pytest.fixture
+def logger():
+    """A real logger that discards output, so log calls are exercised but silent."""
+    log = logging.getLogger("sim-cpdlc-tests")
+    log.handlers = [logging.NullHandler()]
+    log.propagate = False
+    return log
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(monkeypatch, tmp_path):
+    """Point the configuration file at a per-test temporary path.
+
+    load_config(), save_config() and MainWindow._check_first_launch() all read
+    src.config.CONFIG_FILE at call time, so one patch covers every path that
+    could otherwise touch the developer's real config.json.
+
+    Returns:
+        str: Path of the isolated config file, which may not exist yet.
+    """
+    path = tmp_path / "config.json"
+    monkeypatch.setattr(config_module, "CONFIG_FILE", str(path))
+    return str(path)
+
+
+@pytest.fixture(autouse=True)
+def no_network(monkeypatch):
+    """Refuse every outbound request a test did not explicitly fake.
+
+    Tests that need HTTP install their own fake over these (see serving() in
+    test_connection_manager.py); a test's own monkeypatch runs after this one.
+    """
+
+    def refuse(*args, **kwargs):
+        raise RuntimeError("network access in a test")
+
+    monkeypatch.setattr(requests, "get", refuse)
+    monkeypatch.setattr(requests, "post", refuse)
+    monkeypatch.setattr(webbrowser, "open", refuse)
+
+
+@pytest.fixture(autouse=True)
+def no_simbrief(monkeypatch):
+    """Answer every SimBrief lookup with "no flight plan", recording the ids asked for.
+
+    The Connect and PDC dialogs import get_latest_ofp by name, so the patch
+    lands on each dialog module rather than on src.utils.simbrief.
+
+    Returns:
+        list: The SimBrief user ids the dialogs asked for.
+    """
+    asked = []
+
+    def fake(user_id):
+        asked.append(user_id)
+        return None
+
+    monkeypatch.setattr("src.gui.dialogs.connect_dialog.get_latest_ofp", fake)
+    monkeypatch.setattr("src.gui.dialogs.pdc_dialog.get_latest_ofp", fake)
+    return asked
+
+
+class MessageBoxes:
+    """Records wx.MessageBox calls and answers them without showing anything."""
+
+    def __init__(self):
+        self.calls = []
+        self.answer = wx.YES
+
+    def __call__(self, message, caption="Message", style=wx.OK, *args, **kwargs):
+        self.calls.append((message, caption, style))
+        return self.answer
+
+    @property
+    def captions(self):
+        return [caption for _, caption, _ in self.calls]
+
+
+@pytest.fixture(autouse=True)
+def message_boxes(monkeypatch):
+    """Replace wx.MessageBox with a recorder so no test can block on a modal.
+
+    Every module calls it as wx.MessageBox, so patching the wx module attribute
+    covers them all. Set .answer to wx.NO to take the cancel branch of a
+    confirmation.
+    """
+    recorder = MessageBoxes()
+    monkeypatch.setattr(wx, "MessageBox", recorder)
+    return recorder
+
+
+@pytest.fixture
+def wx_app():
+    """A wx application context.
+
+    Torn down rather than shared, because wx allows only one live App at a
+    time and a leaked one would break whichever test ran next.
+    """
+    app = wx.App()
+    yield app
+    # Destroy() only queues a window for deletion; without a yield the whole
+    # object graph behind it -- and for a MainWindow that means a weather
+    # monitor, a SimConnect manager and an update checker -- stays alive for
+    # the rest of the session.
+    wx.SafeYield()
+    leaked = [type(window).__name__ for window in wx.GetTopLevelWindows()]
+    app.Destroy()
+    assert leaked == [], f"top-level windows leaked by this test: {leaked}"
+
+
+@pytest.fixture
+def frame(wx_app):
+    """A top-level window to parent dialogs and timers onto."""
+    frame = wx.Frame(None)
+    yield frame
+    frame.Destroy()
+```
+
+- [ ] **Step 4: Rebuild the `window` fixture in `tests/test_main_window.py` on the new fixtures**
+
+Replace lines 43-71 (the `window` fixture and its docstring) with:
+
+```python
+@pytest.fixture
+def build_window(logger, wx_app, isolated_config, message_boxes):
+    """A factory for the real window, kept offline and non-modal.
+
+    The isolated config file is written first, so _check_first_launch() finds
+    it and shows no welcome dialog, and the update check is switched off so no
+    background thread starts. Every window built here is destroyed at teardown.
+    """
+    built = []
+
+    def build():
+        assert save_config({**DEFAULT_CONFIG, "auto_check_updates": False})
+        window = mw.MainWindow(None, "Sim-CPDLC test", logger)
+        window.Hide()
+        built.append(window)
+        return window
+
+    yield build
+    for window in built:
+        window.weather_monitor.clear()
+        window.weather_monitor.shutdown()
+        window.Destroy()
+
+
+@pytest.fixture
+def window(build_window):
+    return build_window()
+```
+
+and change the import at line 15 to `from src.config import DEFAULT_CONFIG, save_config`.
+
+- [ ] **Step 5: Run the harness tests and the full suite**
+
+Run: `$PY -m pytest tests/test_harness.py -q -p no:cacheprovider`
+Expected: `6 passed`
+
+Run: `$PY -m pytest -q -p no:cacheprovider`
+Expected: `141 passed` (135 + 6), no teardown errors from the leak assertion.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/conftest.py tests/test_harness.py tests/test_main_window.py
+git commit -m "Make the test suite hermetic
+
+Four autouse fixtures now stand between every test and the outside world:
+the config file is a per-test temporary path, requests and webbrowser
+refuse to run, SimBrief lookups answer with no flight plan, and
+wx.MessageBox is a recorder. The wx_app fixture also fails any test that
+leaks a top-level window. The main-window fixture builds on these instead
+of patching load_config and MessageBox itself.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Per-test timeouts and the CI job timeout
+
+**Files:**
+- Modify: `requirements-dev.txt`
+- Modify: `pytest.ini`
+- Modify: `.github/workflows/tests.yml:9-13`
+- Modify: `tests/test_connection_manager.py:408-438`
+
+**Interfaces:**
+- Produces: a 60 s per-test timeout for the whole suite; a 15 minute cap on the CI job.
+
+- [ ] **Step 1: Install pytest-timeout into the venv and pin it**
+
+Run: `$PY -m pip install pytest-timeout==2.4.0`
+Then set `requirements-dev.txt` to:
+
+```
+-r requirements.txt
+pytest==9.1.1
+pytest-timeout==2.4.0
+```
+
+If pip reports that 2.4.0 does not exist, install `pytest-timeout` unpinned, read the installed version with `$PY -m pip show pytest-timeout`, and pin that.
+
+- [ ] **Step 2: Configure the timeout**
+
+`pytest.ini`:
+
+```ini
+[pytest]
+# Scoped to tests/ deliberately: src/utils/test_simbrief.py is a manual script
+# that calls the live SimBrief API, and pytest would otherwise collect it.
+testpaths = tests
+pythonpath = .
+# A test that blocks on a real dialog or a real network call must fail, not
+# hang the run.
+timeout = 60
+```
+
+`.github/workflows/tests.yml`, inside the `test` job after `runs-on`:
+
+```yaml
+    runs-on: windows-latest
+    timeout-minutes: 15
+```
+
+- [ ] **Step 3: Make the two timeout tests patch `requests.post` as well**
+
+In `tests/test_connection_manager.py` replace both tests at the end of the file with:
+
+```python
+def test_install_request_timeout_supplies_a_default(monkeypatch):
+    """hoppie_connector passes no timeout and offers no hook to supply one, so
+    a server that accepts the connection and goes silent blocked forever.
+    socket.setdefaulttimeout() does not help: requests explicitly calls
+    sock.settimeout(None) when given no timeout."""
+    seen = {}
+
+    def _request(url, **kwargs):
+        seen.update(kwargs)
+        return FakeResponse()
+
+    monkeypatch.setattr(requests, "get", _request)
+    monkeypatch.setattr(requests, "post", _request)
+    install_request_timeout(7)
+
+    requests.get("https://example.invalid/")
+    assert seen["timeout"] == 7
+
+    seen.clear()
+    requests.post("https://example.invalid/")
+    assert seen["timeout"] == 7
+
+
+def test_an_explicit_timeout_still_wins(monkeypatch):
+    seen = {}
+
+    def _request(url, **kwargs):
+        seen.update(kwargs)
+        return FakeResponse()
+
+    monkeypatch.setattr(requests, "get", _request)
+    monkeypatch.setattr(requests, "post", _request)
+    install_request_timeout(7)
+
+    requests.get("https://example.invalid/", timeout=1)
+
+    assert seen["timeout"] == 1
+```
+
+- [ ] **Step 4: Verify the plugin is active and the suite is green**
+
+Run: `$PY -m pytest -p no:cacheprovider tests/test_config.py`
+Expected: the header contains `timeout: 60.0s`, tests pass.
+
+Run: `$PY -m pytest -q -p no:cacheprovider`
+Expected: `141 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add requirements-dev.txt pytest.ini .github/workflows/tests.yml tests/test_connection_manager.py
+git commit -m "Give every test a 60 s timeout and the CI job a 15 minute cap
+
+An unstubbed dialog or a real network call used to hang the run for
+GitHub's six-hour default. The two request-timeout tests also patch
+requests.post now, so install_request_timeout no longer leaves a wrapper
+on the real post for the rest of the session.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: The acknowledgement frame, in full
+
+**Files:**
+- Modify: `tests/test_acknowledge_path.py:21-28`
+- Modify: `tests/test_connection_manager.py` (imports at line 17; new test in the "information requests" area or at the end)
+
+**Interfaces:**
+- Consumes: `make_main_window`, `uplink`, `FakeConnectionManager` from `tests.support`; `connected()`, `FakeResponse` already in `test_connection_manager.py`.
+
+- [ ] **Step 1: Replace the weak acknowledgement test and add the MIN test**
+
+In `tests/test_acknowledge_path.py` add `from hoppie_connector import CpdlcResponseRequirement as RR` to the imports and replace `test_wilco_is_sent_with_the_senders_own_min_as_mrn` with:
+
+```python
+def test_wilco_is_a_complete_response_frame(logger):
+    """Recipient, own MIN, response requirement "N", text and the uplink's MIN
+    as MRN. TODOS item 21: acknowledgements once went out as "NE", which some
+    ATC clients ignore, and nothing asserted the requirement."""
+    window, manager, connection = build(logger)
+    message_id = manager.add_message(uplink(STATION, 53))
+
+    window._on_acknowledge_message(message_id, "WILCO")
+
+    assert connection.sent == [(STATION, 1, RR.NO.value, "WILCO", 53)]
+
+
+def test_each_acknowledgement_uses_the_next_own_min(logger):
+    window, manager, connection = build(logger)
+    first = manager.add_message(uplink(STATION, 53))
+    second = manager.add_message(uplink(STATION, 54, "DESCEND TO AND MAINTAIN FL240"))
+
+    window._on_acknowledge_message(first, "WILCO")
+    window._on_acknowledge_message(second, "UNABLE")
+
+    assert [(frame[1], frame[3], frame[4]) for frame in connection.sent] == [
+        (1, "WILCO", 53),
+        (2, "UNABLE", 54),
+    ]
+```
+
+- [ ] **Step 2: Add the wire-level test to `tests/test_connection_manager.py`**
+
+Change the import at line 17 to `from hoppie_connector import CpdlcResponseRequirement as RR, HoppieConnector, HoppieError` and add, after `test_a_rejected_message_is_not_counted_as_a_link_failure`:
+
+```python
+def test_an_acknowledgement_is_transmitted_as_data2_min_mrn_n_text(logger, monkeypatch):
+    """The literal packet the station's client parses. Built by the real
+    hoppie_connector, captured at the HTTP boundary."""
+    seen = {}
+
+    def _get(url, params=None, **kwargs):
+        seen.update(params or {})
+        return FakeResponse("ok")
+
+    cm = connected(logger, monkeypatch)
+    monkeypatch.setattr(requests, "get", _get)
+
+    cm.send_cpdlc("LSAG", 1, RR.NO.value, "WILCO", mrn=53)
+
+    assert seen["packet"] == "/data2/1/53/N/WILCO"
+    assert (seen["to"], seen["type"], seen["from"]) == ("LSAG", "cpdlc", "DLH123")
+```
+
+- [ ] **Step 3: Run the new tests**
+
+Run: `$PY -m pytest tests/test_acknowledge_path.py tests/test_connection_manager.py -q -p no:cacheprovider`
+Expected: all pass (these pin current behaviour).
+
+- [ ] **Step 4: Mutation check: prove the test guards the requirement code**
+
+Edit `src/model/cpdlc_session.py` line 230 from `RR.NO.value,` to `RR.NOT_REQUIRED.value,` and run:
+
+`$PY -m pytest tests/test_acknowledge_path.py -q -p no:cacheprovider`
+Expected: `test_wilco_is_a_complete_response_frame` FAILS showing `'NE'` where `'N'` was expected.
+
+Revert: `git checkout -- src/model/cpdlc_session.py`, rerun, expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_acknowledge_path.py tests/test_connection_manager.py
+git commit -m "Assert the whole acknowledgement frame, down to the wire packet
+
+The end-to-end test discarded the response requirement and the own MIN it
+was written to protect, so reverting TODOS item 21 passed the suite.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: MRN validation and the response table
+
+**Files:**
+- Modify: `tests/test_cpdlc_session.py` (append)
+- Modify: `tests/test_logon_status.py:15-16` and append
+- Modify: `tests/test_message_manager.py` (append; add `import pytest`)
+
+**Interfaces:**
+- Consumes: `uplink(..., mrn=...)` from Task 1.
+
+- [ ] **Step 1: Session-level MRN test**
+
+Append to `tests/test_cpdlc_session.py`:
+
+```python
+def test_logon_accepted_with_a_different_mrn_is_rejected(logger):
+    """TODOS item 24: the MRN must reference our REQUEST LOGON, which always
+    carries MIN 1 because logon() restarts the counter."""
+    session = CpdlcSession(logger, FakeConnectionManager())
+    session.logon("EDDF")
+
+    accepted = session.handle_logon_accepted("EDDF", mrn=2)
+
+    assert accepted is False
+    assert session.get_current_station() == ""
+```
+
+- [ ] **Step 2: Fix the helper in `tests/test_logon_status.py` and add the window-level test**
+
+Replace lines 15-16 with:
+
+```python
+def _logon_accepted_from(station, mrn):
+    """A real acceptance: the station's own MIN 1, referencing our MIN as MRN.
+    All 388 LOGON ACCEPTED uplinks in six months of logs carried an MRN."""
+    return uplink(station, 1, text="LOGON ACCEPTED", rr=RR.NOT_REQUIRED, mrn=mrn)
+```
+
+Append:
+
+```python
+def test_status_bar_is_silent_when_the_mrn_does_not_match(logger):
+    session = CpdlcSession(logger, FakeConnectionManager())
+    session.logon("EDDF")
+    window = make_main_window(logger, session, MessageManager(logger))
+
+    window._on_message_received(_logon_accepted_from("EDDF", 2))
+
+    assert window.status_texts == []
+    assert session.get_current_station() == ""
+```
+
+- [ ] **Step 3: The response table**
+
+Append to `tests/test_message_manager.py` (add `import pytest` at the top):
+
+```python
+RESPONSE_TABLE = [
+    (RR.WILCO_UNABLE, ["WILCO", "UNABLE", "STANDBY"]),
+    (RR.AFFIRM_NEGATIVE, ["AFFIRM", "NEGATIVE", "STANDBY"]),
+    (RR.ROGER, ["ROGER", "STANDBY"]),
+    (RR.YES, ["YES", "NO"]),
+    (RR.NO, []),
+    (RR.NOT_REQUIRED, []),
+]
+
+
+def test_the_response_table_covers_every_requirement_code():
+    assert {rr for rr, _ in RESPONSE_TABLE} == set(RR)
+
+
+@pytest.mark.parametrize("rr, expected", RESPONSE_TABLE, ids=[rr.name for rr, _ in RESPONSE_TABLE])
+def test_the_responses_offered_for_each_requirement_code(logger, rr, expected):
+    """TODOS item 22: "Y" once offered only YES, and "N" wrongly offered NO."""
+    manager = MessageManager(logger)
+    message_id = manager.add_message(uplink(STATION, 9, "CONFIRM SQUAWK", rr=rr))
+
+    assert manager.needs_acknowledgement(message_id, STATION) == (bool(expected), expected)
+```
+
+- [ ] **Step 4: Run the three files**
+
+Run: `$PY -m pytest tests/test_cpdlc_session.py tests/test_logon_status.py tests/test_message_manager.py -q -p no:cacheprovider`
+Expected: all pass.
+
+- [ ] **Step 5: Mutation check**
+
+Edit `src/model/cpdlc_session.py` line 428: change `if mrn != self.pending_logon_min:` to `if False:`. Run the three files again. Expected: `test_logon_accepted_with_a_different_mrn_is_rejected` and `test_status_bar_is_silent_when_the_mrn_does_not_match` FAIL. Revert with `git checkout -- src/model/cpdlc_session.py` and rerun: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_cpdlc_session.py tests/test_logon_status.py tests/test_message_manager.py
+git commit -m "Pin the MRN check on LOGON ACCEPTED and the whole response table
+
+The helper named after the MRN never set one, so the rejecting branch was
+unreachable from the tests, and three of the six response-requirement
+rows had no test at all.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Every downlink, literally, and every failure path
+
+**Files:**
+- Modify: `tests/test_downlink_requests.py` (imports and append)
+
+**Interfaces:**
+- Consumes: `FakeConnectionManager(raise_with=...)`, `.telexes` from Task 1; `make_session`/`session` fixtures already in the file (`STATION = "EGGX"`, callsign `BAW123`).
+
+- [ ] **Step 1: Add the tests**
+
+Change the imports at the top of `tests/test_downlink_requests.py` to:
+
+```python
+import pytest
+from hoppie_connector import HoppieError
+
+from tests.support import FakeConnectionManager
+from src.model.cpdlc_elements import REASON_AIRCRAFT_PERFORMANCE, REASON_WEATHER
+from src.model.cpdlc_session import CpdlcSession
+```
+
+Append:
+
+```python
+# --- the remaining downlinks --------------------------------------------------
+
+
+def test_a_logon_request_uses_min_one_and_expects_an_answer(make_session):
+    session = make_session(station="")
+
+    assert session.logon("EGGX") == (True, "REQUEST LOGON")
+    assert session.connection_manager.sent == [("EGGX", 1, "Y", "REQUEST LOGON", None)]
+    assert (session.pending_logon_station, session.pending_logon_min) == ("EGGX", 1)
+
+
+def test_a_logoff_needs_no_response_and_clears_the_station(session):
+    assert session.logoff() == (True, "LOGOFF")
+    assert session.connection_manager.sent == [(STATION, 1, "NE", "LOGOFF", None)]
+    assert session.get_current_station() == ""
+
+
+@pytest.mark.parametrize(
+    "speed, is_mach, reason, expected",
+    [
+        ("082", True, None, "REQUEST M082"),
+        ("300", False, None, "REQUEST 300K"),
+        ("078", True, REASON_WEATHER, "REQUEST M078 DUE TO WEATHER"),
+    ],
+    ids=["mach", "knots", "mach-with-reason"],
+)
+def test_a_speed_request_names_mach_or_knots(session, speed, is_mach, reason, expected):
+    assert session.send_speed_request(speed, is_mach, reason) == (True, expected)
+
+
+def test_a_when_can_we_expect_inquiry_is_sent_verbatim(session):
+    text = "WHEN CAN WE EXPECT HIGHER LEVEL"
+
+    assert session.send_when_can_we_expect(text) == (True, text)
+
+
+def test_every_request_goes_to_the_current_station_expecting_an_answer(session):
+    session.send_altitude_change_request("FL350")
+    session.send_direct_request("MALOT")
+    session.send_speed_request("082", True)
+    session.send_when_can_we_expect("WHEN CAN WE EXPECT LOWER LEVEL")
+
+    frames = session.connection_manager.sent
+    assert [frame[0] for frame in frames] == [STATION] * 4
+    assert [frame[2] for frame in frames] == ["Y"] * 4
+    assert [frame[1] for frame in frames] == [1, 2, 3, 4]
+
+
+def test_a_telex_goes_to_its_recipient_unchanged(session):
+    assert session.send_telex("EDDF", "HELLO THERE") == (True, "HELLO THERE")
+    assert session.connection_manager.telexes == [("EDDF", "HELLO THERE")]
+
+
+def test_a_pdc_request_is_a_telex_to_the_departure_airport(session):
+    ok, text = session.send_pdc_request("EGLL", "LIMC", "A339", "521", "K")
+
+    assert ok is True
+    assert text == "REQUEST PREDEP CLEARANCE BAW123 A339 TO LIMC AT EGLL STAND 521 ATIS K"
+    assert session.connection_manager.telexes == [("EGLL", text)]
+
+
+def test_a_pdc_request_needs_a_callsign(make_session):
+    session = make_session()
+    session.set_callsign("")
+
+    assert session.send_pdc_request("EGLL", "LIMC", "A339", "521", "K") == (False, None)
+
+
+# --- failure paths ------------------------------------------------------------
+
+SENDS = [
+    ("logon", lambda s: s.logon("EGGX")),
+    ("logoff", lambda s: s.logoff()),
+    ("altitude", lambda s: s.send_altitude_change_request("FL350")),
+    ("direct", lambda s: s.send_direct_request("MALOT")),
+    ("speed", lambda s: s.send_speed_request("082", True)),
+    ("when-can-we", lambda s: s.send_when_can_we_expect("WHEN CAN WE EXPECT HIGHER LEVEL")),
+    ("acknowledgement", lambda s: s.send_acknowledgement(STATION, 7, "WILCO")),
+    ("telex", lambda s: s.send_telex("EDDF", "HELLO")),
+    ("pdc", lambda s: s.send_pdc_request("EGLL", "LIMC", "A339", "521", "K")),
+]
+
+
+@pytest.mark.parametrize("send", [case[1] for case in SENDS], ids=[case[0] for case in SENDS])
+def test_a_transmission_failure_is_reported_and_consumes_no_min(logger, send):
+    """The error text reaches the dialog, and the MIN is not spent, so the
+    next successful send does not leave a gap the station has to explain."""
+    session = CpdlcSession(logger, FakeConnectionManager(raise_with=HoppieError("boom")))
+    session.set_callsign("BAW123")
+    session.current_station = STATION
+
+    assert send(session) == (False, "boom")
+    assert session.cpdlc_min_counter == 1
+```
+
+- [ ] **Step 2: Run the file**
+
+Run: `$PY -m pytest tests/test_downlink_requests.py -q -p no:cacheprovider`
+Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_downlink_requests.py
+git commit -m "Assert every downlink text and every send failure path
+
+Logon, logoff, speed, when-can-we, telex and PDC had no literal test, and
+FakeConnectionManager could not fail, so ten error branches were dead to
+the suite.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: The uplink-handling branches of the main window
+
+**Files:**
+- Create: `tests/test_uplink_handling.py`
+
+**Interfaces:**
+- Consumes: `make_main_window(config=..., simconnect=...)`, `FakeSimConnectManager`, `FakeConnectionManager`, `uplink` from Task 1; `isolated_config` from Task 2 (so `config=` writes land in the temp file).
+
+- [ ] **Step 1: Write the tests**
+
+```python
+"""How the window reacts to uplinks that change session state or tune the radio.
+
+These drive MainWindow._on_message_received with the exact texts the two
+networks send, taken from the maintainer's logs.
+"""
+
+import pytest
+from hoppie_connector import CpdlcResponseRequirement as RR
+
+from tests.support import (
+    FakeConnectionManager,
+    FakeSimConnectManager,
+    make_main_window,
+    uplink,
+)
+from src.model.cpdlc_session import CpdlcSession
+from src.model.message_manager import MessageManager
+
+CURRENT = "EDYY"
+OTHER = "EDUU"
+CONTACT = "CONTACT MARSEILLE CONTROL ON @133.325@."
+
+
+def build(logger, config=None, simconnect=None):
+    connection = FakeConnectionManager()
+    session = CpdlcSession(logger, connection)
+    session.set_callsign("DLH123")
+    session.handle_logon_accepted(CURRENT)
+    simconnect = simconnect if simconnect is not None else FakeSimConnectManager()
+    window = make_main_window(
+        logger, session, MessageManager(logger), config=config, simconnect=simconnect
+    )
+    return window, session, connection, simconnect
+
+
+# --- handover -----------------------------------------------------------------
+
+
+def test_a_handover_logs_off_and_requests_logon_with_the_next_station(logger):
+    window, session, connection, _ = build(logger)
+
+    window._on_message_received(uplink(CURRENT, 48, "HANDOVER @EDGG@", rr=RR.NOT_REQUIRED))
+
+    assert session.get_current_station() == ""
+    assert session.pending_logon_station == "EDGG"
+    assert connection.sent == [("EDGG", 1, RR.YES.value, "REQUEST LOGON", None)]
+    assert window.status_texts == ["Logged off from EDYY.", "Pending logon to EDGG."]
+    assert window.polling_controller.active_calls == 1
+
+
+def test_a_handover_from_another_station_is_shown_but_not_acted_on(logger):
+    window, session, connection, _ = build(logger)
+
+    window._on_message_received(uplink(OTHER, 48, "HANDOVER @EDGG@", rr=RR.NOT_REQUIRED))
+
+    assert session.get_current_station() == CURRENT
+    assert connection.sent == []
+    assert window.status_texts == []
+    assert len(window.message_view.added) == 1
+
+
+# --- logoff -------------------------------------------------------------------
+
+
+def test_a_logoff_from_the_current_station_ends_the_logon(logger):
+    window, session, _, _ = build(logger)
+
+    window._on_message_received(uplink(CURRENT, 5, "LOGOFF", rr=RR.NOT_REQUIRED))
+
+    assert session.get_current_station() == ""
+    assert window.status_texts == ["Logged off from EDYY."]
+
+
+@pytest.mark.parametrize(
+    "sender, text",
+    [(OTHER, "LOGOFF"), (CURRENT, "LOGOFF NOT REQUIRED AT THIS TIME")],
+    ids=["other-station", "not-an-exact-logoff"],
+)
+def test_other_logoff_texts_leave_the_logon_alone(logger, sender, text):
+    """TODOS item 23: substring matching once logged off on the second text."""
+    window, session, _, _ = build(logger)
+
+    window._on_message_received(uplink(sender, 5, text, rr=RR.NOT_REQUIRED))
+
+    assert session.get_current_station() == CURRENT
+    assert window.status_texts == []
+
+
+# --- protocol noise -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["CURRENT ATC UNIT@_@EDYY@_@MAASTRICHT RADAR", "CURRENT ATS UNIT@_@EDYY@_@MAASTRICHT RADAR"],
+    ids=["atc", "ats"],
+)
+def test_current_unit_announcements_are_hidden(logger, text):
+    window, _, _, _ = build(logger)
+
+    window._on_message_received(uplink(CURRENT, 2, text, rr=RR.NOT_REQUIRED))
+
+    assert window.message_view.added == []
+    assert window.message_manager.message_log == {}
+    assert window.status_texts == []
+
+
+# --- CONTACT / MONITOR auto-tune ----------------------------------------------
+
+
+def test_a_contact_instruction_tunes_the_standby_radio(logger):
+    window, _, _, simconnect = build(logger)
+
+    window._on_message_received(uplink(CURRENT, 7, CONTACT))
+
+    assert simconnect.tuned == [133.325]
+    assert window.status_texts == []
+
+
+def test_auto_tune_can_be_switched_off(logger):
+    window, _, _, simconnect = build(logger, config={"auto_tune_com1": False})
+
+    window._on_message_received(uplink(CURRENT, 7, CONTACT))
+
+    assert simconnect.tuned == []
+
+
+def test_a_failed_auto_tune_tells_the_pilot_the_frequency(logger):
+    window, _, _, simconnect = build(logger, simconnect=FakeSimConnectManager(result=False))
+
+    window._on_message_received(uplink(CURRENT, 7, CONTACT))
+
+    assert simconnect.tuned == [133.325]
+    assert window.status_texts == ["Auto-tune failed \u2014 set 133.325 manually"]
+
+
+def test_a_contact_from_another_station_is_not_tuned(logger):
+    window, _, _, simconnect = build(logger)
+
+    window._on_message_received(uplink(OTHER, 7, CONTACT))
+
+    assert simconnect.tuned == []
+```
+
+- [ ] **Step 2: Run the file**
+
+Run: `$PY -m pytest tests/test_uplink_handling.py -q -p no:cacheprovider`
+Expected: `10 passed`. If `test_auto_tune_can_be_switched_off` fails with the frequency tuned, the `config=` path is not reaching the isolated file: check that `make_main_window` calls `save_config` and that `isolated_config` is autouse.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_uplink_handling.py
+git commit -m "Cover the handover, logoff, noise-filter and auto-tune branches
+
+Only LOGON ACCEPTED had a test through the window. The handover branch is
+the automatic re-logon to the next sector, and the auto-tune branch was
+untestable because the fixture never set a SimConnect manager.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Menu items fire the handlers they claim to
+
+**Files:**
+- Modify: `tests/test_main_window.py:20-40` (constants), `:177-189` (replace the existence test, strengthen the guard test)
+
+**Interfaces:**
+- Consumes: `build_window` factory fixture from Task 2, `message_boxes` from Task 2.
+
+- [ ] **Step 1: Replace the handler list with the binding table**
+
+Replace lines 20-40 (`MENU_TITLES` and `MENU_HANDLERS`) with:
+
+```python
+MENU_TITLES = ["File", "Requests"]
+
+# Which handler each menu item must fire. Every handler is replaced on the
+# class before the window is built, so the Bind() calls in _init_menu pick up
+# the recorders; posting the item's command event then shows which one ran.
+MENU_BINDINGS = {
+    "File": {
+        "Connect": "on_connect_or_disconnect",
+        "Settings": "on_settings",
+        "Check for Updates": "on_check_updates",
+        "About": "on_about",
+        "Exit": "on_exit",
+    },
+    "Requests": {
+        "PDC": "on_pdc_request",
+        "Logon": "on_logon",
+        "Logoff": "on_logoff",
+        "Altitude change": "on_altitude_change",
+        "Direct to": "on_direct_request",
+        "Speed change": "on_speed_request",
+        "When can we expect": "on_when_can_we_expect",
+        "Telex message": "on_telex",
+        "ATIS and Weather request": "on_weather_request",
+        "Automatic weather updates": "on_weather_subscriptions",
+    },
+}
+```
+
+Add `import wx` to the imports.
+
+- [ ] **Step 2: Replace `test_every_menu_item_has_a_handler` and strengthen the guard test**
+
+Replace the two tests (`test_every_menu_item_has_a_handler` and `test_a_request_needing_a_connection_is_refused_while_disconnected`) with:
+
+```python
+def _recorder(name, fired):
+    def handler(self, event):
+        fired.append(name)
+
+    return handler
+
+
+def test_every_menu_item_fires_its_own_handler(build_window, monkeypatch):
+    """A deleted or mis-targeted Bind() shows up as a dead or wrong menu item;
+    checking that the methods merely exist could not see either."""
+    fired = []
+    for names in MENU_BINDINGS.values():
+        for name in names.values():
+            monkeypatch.setattr(mw.MainWindow, name, _recorder(name, fired))
+    window = build_window()
+    menu_bar = window.GetMenuBar()
+
+    observed = {}
+    for menu_index in range(menu_bar.GetMenuCount()):
+        title = menu_bar.GetMenuLabel(menu_index).replace("&", "")
+        for item in menu_bar.GetMenu(menu_index).GetMenuItems():
+            if item.IsSeparator():
+                continue
+            fired.clear()
+            window.ProcessEvent(wx.CommandEvent(wx.wxEVT_MENU, item.GetId()))
+            observed.setdefault(title, {})[item.GetItemLabelText()] = (
+                fired[0] if len(fired) == 1 else list(fired)
+            )
+
+    assert observed == MENU_BINDINGS
+
+
+# --- guards -------------------------------------------------------------------
+
+
+def test_a_request_needing_a_connection_is_refused_and_the_user_is_told(window, message_boxes):
+    assert window._require_connection("test") is False
+    assert message_boxes.captions == ["Not Connected"]
+```
+
+- [ ] **Step 3: Run the file**
+
+Run: `$PY -m pytest tests/test_main_window.py -q -p no:cacheprovider`
+Expected: all pass.
+
+- [ ] **Step 4: Mutation check**
+
+Comment out line 227 of `src/gui/main_window.py` (`self.Bind(wx.EVT_MENU, self.on_altitude_change, menu_item_altitude_change)`) and rerun the file. Expected: `test_every_menu_item_fires_its_own_handler` FAILS with `"Altitude change": []` in the diff. Revert with `git checkout -- src/gui/main_window.py` and rerun: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_main_window.py
+git commit -m "Drive every menu item and assert which handler it fires
+
+The old test only checked that the handler methods existed, so a dropped
+Bind() passed. The connection guard test now also checks the user was
+told.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: The response context menu: its items, its firing, its cleanup
+
+**Files:**
+- Modify: `tests/test_message_view.py` (append)
+
+**Interfaces:**
+- Consumes: `uplink`, `panel` fixture already in the file (`STATION = "LSAG"`).
+
+- [ ] **Step 1: Add the test**
+
+Append to `tests/test_message_view.py`:
+
+```python
+def test_the_response_menu_offers_every_response_and_fires_the_chosen_one(panel, logger):
+    """The menu is destroyed as soon as it closes, so its items are captured
+    inside the fake PopupMenu; the second item is chosen from there. TODOS
+    item 2: the per-item bindings must be gone once the menu has closed, or a
+    reused id would fire a stale response."""
+    manager = MessageManager(logger)
+    acknowledged = []
+    view = MessageView(
+        panel, logger, manager, lambda mid, resp: acknowledged.append((mid, resp)), lambda: STATION
+    )
+    message_id = manager.add_message(uplink(STATION, 4))
+    shown = {}
+
+    def choose_second(menu):
+        shown["labels"] = [item.GetItemLabelText() for item in menu.GetMenuItems()]
+        shown["ids"] = [item.GetId() for item in menu.GetMenuItems()]
+        panel.ProcessEvent(wx.CommandEvent(wx.wxEVT_MENU, shown["ids"][1]))
+
+    panel.PopupMenu = choose_second
+    view.add_message(message_id)
+    view.message_list.Select(0)
+
+    view.on_context_menu(None)
+
+    assert shown["labels"] == ["Respond: WILCO", "Respond: UNABLE", "Respond: STANDBY"]
+    assert acknowledged == [(message_id, "UNABLE")]
+
+    panel.ProcessEvent(wx.CommandEvent(wx.wxEVT_MENU, shown["ids"][1]))
+    assert acknowledged == [(message_id, "UNABLE")], "binding survived the menu"
+```
+
+- [ ] **Step 2: Run the file**
+
+Run: `$PY -m pytest tests/test_message_view.py -q -p no:cacheprovider`
+Expected: all pass.
+
+- [ ] **Step 3: Mutation check**
+
+In `src/gui/message_view.py` comment out lines 168-169 (the `for menu_item in menu_items: self.parent.Unbind(...)` loop) and rerun. Expected: the new test FAILS at "binding survived the menu". Revert with `git checkout -- src/gui/message_view.py` and rerun: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_message_view.py
+git commit -m "Assert the response menu's items, its firing and its cleanup
+
+The existing test only checked that a menu popped. Now the labels, the
+response the chosen item sends and the removal of the bindings afterwards
+are all pinned.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: `load_config` and `save_config`
+
+**Files:**
+- Modify: `tests/test_config.py` (imports and append)
+
+**Interfaces:**
+- Consumes: `isolated_config` from Task 2.
+
+- [ ] **Step 1: Add the tests**
+
+Change the imports of `tests/test_config.py` to:
+
+```python
+import os
+from pathlib import Path
+
+from src.config import (
+    DEFAULT_CONFIG,
+    DEFAULT_WEATHER_INTERVAL_MINUTES,
+    MAX_WEATHER_INTERVAL_MINUTES,
+    MIN_WEATHER_INTERVAL_MINUTES,
+    load_config,
+    save_config,
+    weather_interval_minutes,
+)
+```
+
+Append:
+
+```python
+# --- reading and writing the file ---------------------------------------------
+
+
+def test_a_missing_file_yields_a_fresh_copy_of_the_defaults():
+    loaded = load_config()
+
+    assert loaded == DEFAULT_CONFIG
+    assert loaded is not DEFAULT_CONFIG
+
+
+def test_missing_keys_are_filled_in_and_present_ones_kept(isolated_config):
+    Path(isolated_config).write_text('{"hoppie_logon_code": "ABC"}')
+
+    loaded = load_config()
+
+    assert loaded["hoppie_logon_code"] == "ABC"
+    assert set(loaded) == set(DEFAULT_CONFIG)
+
+
+def test_invalid_json_yields_the_defaults(isolated_config):
+    Path(isolated_config).write_text("{not json")
+
+    assert load_config() == DEFAULT_CONFIG
+
+
+def test_only_a_mapping_can_be_saved():
+    assert save_config("nope") is False
+
+
+def test_a_saved_config_round_trips():
+    assert save_config({**DEFAULT_CONFIG, "simbrief_userid": "42"}) is True
+
+    assert load_config()["simbrief_userid"] == "42"
+
+
+def test_a_failed_write_leaves_the_previous_file_and_no_temp_file_behind(
+    isolated_config, monkeypatch
+):
+    """TODOS item 5: the write is atomic. A PermissionError from os.replace is
+    what Windows raises when the file is open elsewhere."""
+    save_config({**DEFAULT_CONFIG, "simbrief_userid": "before"})
+
+    def refuse(src, dst):
+        raise PermissionError(13, "file in use", dst)
+
+    monkeypatch.setattr(os, "replace", refuse)
+
+    assert save_config({**DEFAULT_CONFIG, "simbrief_userid": "after"}) is False
+    assert load_config()["simbrief_userid"] == "before"
+    assert [path.name for path in Path(isolated_config).parent.iterdir()] == ["config.json"]
+```
+
+- [ ] **Step 2: Run the file**
+
+Run: `$PY -m pytest tests/test_config.py -q -p no:cacheprovider`
+Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_config.py
+git commit -m "Test reading, writing and the atomic replace of the config file
+
+These functions hold the logon codes and had no test beyond the interval
+clamp.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Table tests for the two parsers
+
+**Files:**
+- Create: `tests/test_frequency_parser.py`
+- Create: `tests/test_message_formatting.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+
+- [ ] **Step 1: Frequency parser table**
+
+Create `tests/test_frequency_parser.py`:
+
+```python
+"""What extract_contact_frequency tunes, on the texts the networks send.
+
+Texts are given as the window sees them: after "@" separators have been
+turned into spaces and whitespace collapsed.
+"""
+
+import pytest
+
+from src.utils.frequency_parser import extract_contact_frequency
+
+CASES = [
+    ("CONTACT MAASTRICHT 132.850", 132.85),
+    ("CONTACT MARSEILLE CONTROL ON 133.325 .", 133.325),
+    ("CONTACT MAASTRICHT ON 132.855 MHZ", 132.855),
+    ("MONITOR UNICOM 122.8", 122.8),
+    ("AT KONOL CONTACT LONDON CONTROL 127.425", 127.425),
+    ("CONTACT MAASTRICHT 132.850 OR 121.500", 132.85),
+    ("CONTACT EDDF_TWR 118.700", 118.7),
+    ("CONTACT MAASTRICHT\n132.850", 132.85),
+    ("CONTACT LOWER LIMIT 118.000", 118.0),
+    ("CONTACT UPPER LIMIT 136.990", 136.99),
+    ("CLIMB TO FL350 REPORT LEVEL", None),
+    ("CONTACT RHEIN RADAR 136.995", None),
+    ("CONTACT LANGEN RADAR 117.950", None),
+    ("CONTACT UPPER LIMIT 137.000", None),
+]
+
+
+@pytest.mark.parametrize("text, expected", CASES, ids=[case[0][:32] for case in CASES])
+def test_the_frequency_read_from_a_contact_or_monitor_instruction(text, expected):
+    assert extract_contact_frequency(text) == expected
+```
+
+- [ ] **Step 2: Message formatting tables**
+
+Create `tests/test_message_formatting.py`:
+
+```python
+"""The CPDLC packet-to-text helpers the list and the detail pane rely on."""
+
+import pytest
+from hoppie_connector import CpdlcResponseRequirement as RR
+
+from src.utils.message_formatting import (
+    extract_message_content,
+    format_list_text,
+    format_message_text,
+)
+
+
+@pytest.mark.parametrize("rr", list(RR), ids=[rr.name for rr in RR])
+def test_the_packet_prefix_is_stripped_with_and_without_an_mrn(rr):
+    assert extract_message_content(f"/data2/12//{rr.value}/CLIMB TO FL350") == "CLIMB TO FL350"
+    assert extract_message_content(f"/data2/12/3/{rr.value}/WILCO") == "WILCO"
+
+
+@pytest.mark.parametrize("text", ["CLIMB TO FL350", "", None], ids=["plain", "empty", "none"])
+def test_text_without_a_prefix_is_returned_unchanged(text):
+    assert extract_message_content(text) == text
+
+
+def test_the_detail_pane_puts_each_field_on_its_own_line():
+    assert format_message_text("CONTACT CLEVELAND CENTER ON @123.450@.") == (
+        "CONTACT CLEVELAND CENTER ON\n123.450."
+    )
+    assert format_message_text("CURRENT ATC UNIT@_@EDUU@_@RHEIN RADAR") == (
+        "CURRENT ATC UNIT\nEDUU\nRHEIN RADAR"
+    )
+
+
+def test_the_list_row_carries_no_separators():
+    row = format_list_text("CONTACT CLEVELAND CENTER ON @123.450@.")
+
+    assert "@" not in row
+    assert "123.450" in row
+    assert format_list_text("CURRENT ATC UNIT@_@EDUU@_@RHEIN RADAR").split() == [
+        "CURRENT", "ATC", "UNIT", "EDUU", "RHEIN", "RADAR",
+    ]
+```
+
+- [ ] **Step 3: Run both files**
+
+Run: `$PY -m pytest tests/test_frequency_parser.py tests/test_message_formatting.py -q -p no:cacheprovider`
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_frequency_parser.py tests/test_message_formatting.py
+git commit -m "Add table tests for the frequency parser and the packet formatters
+
+Neither module had a test. The parser decides what gets tuned into the
+simulator radio; the formatters produce the text NVDA reads.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: Regenerate `tests/README.md` and run the whole suite
+
+**Files:**
+- Modify: `tests/README.md`
+
+- [ ] **Step 1: Rewrite the README**
+
+```markdown
+# Tests
+
+Offline checks for the CPDLC request formats, the message handling in the
+window, the automatic weather update logic and the main window wiring. They
+need no network connection, no running simulator and no ACARS logon code, and
+the fixtures in `conftest.py` make sure of it: every test gets a temporary
+config file, outbound requests and browser launches raise, SimBrief lookups
+answer with no flight plan, and `wx.MessageBox` is a recorder.
+
+Run them from the repository root:
+
+```bash
+pip install -r requirements-dev.txt
+pytest
+```
+
+The GUI tests build real wx windows, dialogs and timers, so they need a desktop
+session; CI runs them on Windows for that reason. Each test is limited to 60
+seconds.
+
+Shared test doubles (`uplink`, `FakeConnectionManager`, `FakeSimConnectManager`,
+`make_main_window`, ...) live in `support.py`; import them with
+`from tests.support import ...`.
+
+| File | Covers |
+| --- | --- |
+| `test_acknowledge_path.py` | Responding to an uplink, end to end from the window, down to the frame |
+| `test_config.py` | Reading, writing and clamping the configuration |
+| `test_connection_manager.py` | The network boundary: errors, timeouts, reconnection, the wire packets |
+| `test_cpdlc_session.py` | Session state and logon acceptance validation, including the MRN check |
+| `test_dialogs.py` | The validation the weather request dialog applies before submitting |
+| `test_downlink_requests.py` | The exact text of every downlink the client can send, and every send failure |
+| `test_frequency_parser.py` | Which CONTACT/MONITOR texts tune the standby radio |
+| `test_harness.py` | The hermetic fixtures themselves |
+| `test_logon_status.py` | Logon state as reported to the user |
+| `test_main_window.py` | The real window: menu bindings, message list, weather toggles |
+| `test_main_window_wiring.py` | `_init_ui` alone, on a stripped-down frame |
+| `test_message_formatting.py` | Packet prefix stripping and the list and detail text |
+| `test_message_manager.py` | Message storage, addressing and the full response table |
+| `test_message_view.py` | The message list and its response context menu |
+| `test_polling_controller.py` | Which messages speed up polling, and the poll intervals |
+| `test_uplink_handling.py` | HANDOVER, LOGOFF, protocol noise and auto-tune through the window |
+| `test_weather_monitor.py` | Weather change detection and the update timer lifecycle |
+| `test_weather_parsing.py` | The report registry, the ATIS letter and the report formatters |
+
+`test_downlink_requests.py` asserts message text literally, so a change to a
+format shows up there before it reaches the network.
+```
+
+- [ ] **Step 2: Run the whole suite one last time and check the tree**
+
+Run: `$PY -m pytest -q -p no:cacheprovider`
+Expected: all pass, roughly 195 tests, no teardown errors.
+
+Run: `git status --short`
+Expected: only `tests/README.md` modified (nothing under `src/` touched).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/README.md
+git commit -m "Regenerate the tests README for the hermetic suite
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage (Package 1 section): fixtures `isolated_config`, `no_network`, `no_simbrief` (Task 2); leaked-window assertion (Task 2); helpers in `tests/support.py` with `uplink(mrn=)`, `raise_with`, `FakeSimConnectManager`, `make_main_window(config=, simconnect=)`, `message_boxes` (Tasks 1–2); `pytest-timeout`, `timeout-minutes`, `requests.post` in the timeout tests (Task 3); acknowledgement frame and wire packet (Task 4); MRN mismatch, response table (Task 5); every downlink and failure path (Task 6); HANDOVER, LOGOFF, noise filter, CONTACT branches (Task 7); menu binding via `ProcessEvent` (Task 8); context-menu labels, firing, no stale binding (Task 9); `load_config`/`save_config` including the atomic-write failure (Task 10); parser tables (Task 11); README regenerated (Task 12).
+- Behaviour a later package changes (strict station scoping, `N/A` substitution, single reconnection attempt, unit-less CONTACT texts) is deliberately not pinned here.
+- Names used across tasks: `tests.support` symbols are defined once in Task 1 and used unchanged; `isolated_config`, `message_boxes`, `no_simbrief`, `build_window` are defined in Task 2 and used in Tasks 7, 8 and 10.

--- a/docs/superpowers/specs/2026-09-03-audit-fixes-design.md
+++ b/docs/superpowers/specs/2026-09-03-audit-fixes-design.md
@@ -1,0 +1,447 @@
+# Audit fixes — umbrella design
+
+**Date:** 2026-09-03
+**Branch:** `claude/audit-fix-design`, cut from `main` at `9c06458`.
+**Status:** approved in discussion, awaiting review of this document.
+
+## Purpose
+
+`docs/audit/2026-09-03-codebase-audit.md` lists 3 High, 12 Medium, 21 Low and 5
+Info findings against `main`. This document settles the decisions those findings
+depend on, groups the work into six packages, and fixes the interfaces each
+package introduces, so that each package can then get its own implementation
+plan and land as its own pull request.
+
+## Inputs
+
+Two sources beyond the code:
+
+- The audit report and its four lens reports under `docs/audit/`.
+- The application log on the maintainer's machine, 2026-03-04 to 2026-09-03:
+  242 starts, 239 SayIntentions and 21 Hoppie connections, 2,693 received
+  messages (2,437 CPDLC, 256 telex), 163 handovers.
+
+What the log established:
+
+| Question from the audit | Answer from the log |
+|---|---|
+| Do uplinks contain characters the library refuses? | Not observably. Every received CPDLC uplink is template-shaped and inside the whitelist; 3 of 256 telexes carry punctuation, which telex parsing accepts anyway. `@@` never appears; `@_@` appears only in `CURRENT ATC UNIT`. |
+| How do handovers behave? | In 22 of 163 handovers a WILCO-required instruction from the previous station (typically `CONTACT … ON @freq@.`) arrived after the handover, in the same poll batch as the new station's `LOGON ACCEPTED`. The pilot acknowledged 16 of them under older builds; current `main` makes them unanswerable. |
+| How do outages look? | Server-side poll errors: `callsign already in use` (5), `invalid logon code` (4). One 145-poll Hoppie outage; one 8-poll SayIntentions outage on 2026-07-17 that recovered by itself after six minutes, which current `main` would have turned into a permanent stop. |
+| Is send rate a problem? | 19 of 975 send gaps were under 5 s; SayIntentions rejected one ROGER with `rate_limit`. |
+| Non-ASCII bodies? | Never. |
+| Do `LOGON ACCEPTED` uplinks carry an MRN? | All 388 do. |
+
+## Decisions
+
+1. Test harness first, then five behaviour packages in the order below. Each package is one plan and one pull request.
+2. **Handover window.** Unanswered uplinks stay answerable when they come from the current station or from the station the aircraft was handed over from, for 10 minutes after the handover. Responses are always addressed to the message's own sender.
+3. **Link loss is never terminal.** After three consecutive poll failures the link is "lost": the user is told with a SYSTEM row and the notification sound, polling continues on a back-off ladder of 20 s, 60 s, 120 s, 300 s (cap), and a successful poll or re-verification restores it, again announced. Only `invalid logon code` stops polling.
+4. **Session reset.** CPDLC session state is reset on File > Disconnect (whether or not the LOGOFF could be sent), on a connect with a different callsign or network, and on a fatal link error. Automatic reconnection with the same identity keeps the ATC logon.
+5. **One network worker** owns every network call: connect, poll, sends, weather, SimBrief, update check. Sends are paced at least 5 s apart.
+6. **Update checker** opens the release page and never closes the application; the automatic check is skipped when the app runs from source.
+7. **Logon while logged on** sends LOGOFF to the current station first, then REQUEST LOGON, restarting the MIN counter only after that LOGOFF.
+8. Smaller calls settled by evidence: the `@@` → `N/A` substitution is removed; README states Python 3.12; the library-warning mitigation for unparseable uplinks is logging plus a SYSTEM row, not a permissive parser; the non-ASCII decode shim is optional and last.
+
+## Packages
+
+| # | Package | Findings closed |
+|---|---|---|
+| 1 | Test harness hermeticity and protocol regression tests | M-11, M-12, L-21 (part) |
+| 2 | Link resilience and message integrity | H-1, H-2, M-2 (optional), M-3, M-4, M-6, L-1 |
+| 3 | Session and protocol state | handover race, M-1, M-7, L-2, L-3 |
+| 4 | One network worker | H-3, M-5, M-9, L-4, L-5, L-9, L-13, L-14, L-15 |
+| 5 | Dialog validation and feedback | M-8, L-7, L-10, L-11, L-12, L-16, L-17 |
+| 6 | Release, packaging, docs, hygiene | M-10, L-6, L-8, L-18, L-19, L-20, I-1 to I-5 |
+
+New constants, all in `src/config.py`, so every timing in this design is tunable in one place:
+
+```python
+LINK_BACKOFF_MS = (20000, 60000, 120000, 300000)   # package 2
+PREVIOUS_STATION_WINDOW_SECONDS = 600              # package 3
+PENDING_LOGON_TIMEOUT_SECONDS = 600                # package 3
+SEND_SPACING_SECONDS = 5                            # package 4
+INFOREQ_SPACING_SECONDS = 1                         # package 4
+NETWORK_TIMEOUT = (10, 15)                          # package 4: connect, read
+```
+
+---
+
+## Package 1: test harness hermeticity and protocol regression tests
+
+**Goal.** No test can touch the maintainer's real configuration, the network,
+SimBrief or the simulator, and the protocol behaviour that later packages must
+preserve is pinned.
+
+### Fixtures (`tests/conftest.py`)
+
+Three new autouse fixtures:
+
+- `isolated_config`: `monkeypatch.setattr(src.config, "CONFIG_FILE", str(tmp_path / "config.json"))`. `load_config`, `save_config` and `_check_first_launch` all read the module attribute at call time, so one patch covers them.
+- `no_network`: replaces `requests.get`, `requests.post` and `webbrowser.open` with functions that raise `RuntimeError("network access in a test")`. A test that needs HTTP installs `serving()` over it, as `test_connection_manager.py` already does.
+- `no_simbrief`: patches `src.gui.dialogs.connect_dialog.get_latest_ofp` and `src.gui.dialogs.pdc_dialog.get_latest_ofp` to return `None`.
+
+`wx_app` asserts `wx.GetTopLevelWindows()` is empty after its `SafeYield`, so a
+leaked window fails the test that leaked it.
+
+### Helpers (`tests/support.py`, new)
+
+Everything currently imported with `from conftest import …` moves here:
+`uplink(sender, min_value, text, rr, mrn=None)`, `FakeConnectionManager`
+(gains `raise_with=None`; when set, every send raises it), `RecordingMessageView`,
+`FakePollingController`, and `make_main_window(logger, session, manager,
+config=None, simconnect=None)`, which now sets `window.simconnect_manager` to a
+`FakeSimConnectManager` (records every frequency passed to
+`set_com1_standby_mhz`, returns a configurable result) and patches
+`src.gui.main_window.load_config` to return the supplied dict. A `message_boxes`
+fixture replaces the silent `wx.MessageBox` stub: it records `(text, caption,
+style)` and returns `.answer`, default `wx.YES`.
+
+### Tooling
+
+`pytest-timeout` added to `requirements-dev.txt` with `timeout = 60` in
+`pytest.ini`; `timeout-minutes: 15` on the CI test job; the two
+`install_request_timeout` tests patch `requests.post` as well as `requests.get`.
+
+### Regression tests added (current behaviour)
+
+- Acknowledgement frame: `connection.sent[-1] == (STATION, 1, RR.NO.value, "WILCO", 53)`; a second acknowledgement uses own MIN 2; through the real `HoppieConnector` with a capturing `requests.get`, `params["packet"] == "/data2/1/53/N/WILCO"`.
+- `handle_logon_accepted("EDDF", mrn=2)` with pending MIN 1 is rejected; through the window, a properly built `/data2/1/2/NE/LOGON ACCEPTED` leaves the status bar silent.
+- Response table parametrised over all six `CpdlcResponseRequirement` members.
+- Every downlink literally: `logon`, `logoff`, `send_speed_request` (Mach and knots), `send_when_can_we_expect`, `send_telex`, `send_pdc_request`, each also with `raise_with=HoppieError("boom")` giving `(False, "boom")`.
+- `_on_message_received` branches through `make_main_window`: `HANDOVER EDGG` (station cleared, `("EDGG", 1, "Y", "REQUEST LOGON", None)` sent, both status texts, active polling bumped; nothing from a non-current station), `LOGOFF` and `LOGOFF NOT REQUIRED AT THIS TIME`, `CURRENT ATC UNIT`/`CURRENT ATS UNIT` filtered, `CONTACT MARSEILLE CONTROL 133.325` tuned / disabled / failed-status / non-current station.
+- Menu binding: for every item of every menu, the expected handler is replaced by a recorder and `window.ProcessEvent(wx.CommandEvent(wx.wxEVT_MENU, item.GetId()))` must fire exactly it; replaces the existence-only check.
+- Context menu: labels `["Respond: WILCO", "Respond: UNABLE", "Respond: STANDBY"]`, firing the second item calls `on_acknowledge(message_id, "UNABLE")`, re-posting the same id after the menu closed fires nothing.
+- `load_config` / `save_config` on `tmp_path`: missing-key back-fill, invalid JSON, non-dict, and an `os.replace` failure leaving the original intact with no `.tmp` behind.
+- Tables for `frequency_parser` (the ten audit cases plus boundaries `136.990`/`137.000`) and `message_formatting` (prefix stripping for every RR, `@` handling).
+- `tests/README.md` regenerated from the real file list.
+
+Tests that pin behaviour a later package changes (strict station scoping, the
+`N/A` substitution, the single reconnection attempt) are left as they are here
+and rewritten by that package.
+
+---
+
+## Package 2: link resilience and message integrity
+
+**Goal.** A poll failure is reported honestly, never silently ends the session,
+and never loses a message the server has already handed over.
+
+### `LinkState` (`src/controller/link_state.py`, new)
+
+```python
+class LinkState:
+    CONNECTED = "connected"   # last poll succeeded
+    DEGRADED = "degraded"     # 1-2 consecutive failures
+    LOST = "lost"             # 3 or more; back-off active
+    FATAL = "fatal"           # server said the logon code is invalid
+
+    def __init__(self, on_change, max_failures=MAX_CONNECTION_FAILURES,
+                 backoff_ms=LINK_BACKOFF_MS): ...
+    def record_poll(self, result: "PollResult") -> None
+    def record_reverify(self, ok: bool) -> None
+    def next_delay_ms(self) -> int | None   # back-off delay while LOST, else None
+    def reset(self) -> None
+    state: str
+    failures: int
+```
+
+`on_change(old, new, reason)` fires on every transition. Entering LOST starts
+the ladder at its first rung; each further failure advances one rung and stays
+at the cap; any success returns to CONNECTED and resets the ladder. A
+`PollResult` whose `fatal` flag is set moves to FATAL from any state.
+
+### `ConnectionManager.poll()` returns a `PollResult`
+
+```python
+@dataclass
+class UnreadableMessage:
+    sender: str
+    raw: str          # the packet as the server sent it
+
+@dataclass
+class PollResult:
+    ok: bool
+    messages: list            # HoppieMessage objects
+    unreadable: list          # UnreadableMessage objects
+    reason: str | None        # server reason or error text on failure
+    fatal: bool = False       # True for "invalid logon code"
+```
+
+`poll()` wraps `cnx.poll` in `warnings.catch_warnings(record=True)` filtered to
+`HoppieWarning`; each recorded warning becomes an `UnreadableMessage` (sender
+and raw packet parsed from the warning text, which carries the item dict) and an
+ERROR log line. A `HoppieError` whose reason contains `invalid logon code`
+produces `fatal=True`. `callsign already in use` is an ordinary failure but the
+reason is carried so the window can announce it once per episode. Existing
+fakes that return `(messages, None)` are updated to return a `PollResult`.
+
+### `PollingController`
+
+- Owns `self.link = LinkState(on_change=self._on_link_change)`; `start()` calls `link.reset()` and clears `_reported_failure`.
+- `_schedule_next()` uses `link.next_delay_ms()` when it is not `None`, otherwise the existing active/idle logic.
+- The tick: submit the poll (synchronously in this package; the worker arrives in package 4), `link.record_poll(result)`, process messages, then, while LOST and only when the back-off delay has elapsed, call `connection_manager.attempt_reconnection()` and `link.record_reverify(ok)`. The branch no longer calls `stop()`. FATAL stops the timer.
+- Message loop (M-3): each callback runs in its own `try`; a failure is logged with traceback and the loop continues; the first exception is re-raised after the loop so the reporter still sees it.
+- `unreadable_callback(unreadable)` is a new constructor argument alongside `message_callback`.
+- Status texts, all through `_set_status`: DEGRADED "Connection problem (n/3) - retrying...", LOST "Connection lost - retrying in N s", back to CONNECTED "Connection restored.". `_report_connection_state` reads `connection_failures` only (L-1); send failures keep their dialog.
+- `link_callback(old, new, reason)` constructor argument so the window can react.
+
+### `ConnectionManager`
+
+- `attempt_reconnection()` catches `Exception`, logs it, and on failure keeps the existing connector (so `is_connected()` stays true and File > Disconnect still works). On FATAL the controller only stops its timer; the window's `link_callback` is what calls `disconnect()` and resets the session, so there is one owner for the teardown.
+- `connect()` likewise converts any non-`HoppieError` into a `HoppieError` for the caller (the classification into transport/protocol is unchanged for counting purposes).
+- `_SERVER_INFO_PATTERN` becomes `^\{server info \{(.*)\}\}$`; `send_info_request` raises "No <report> available for <ICAO>" for a bare `ok`, `ok ` and an empty envelope; `error {reason}` is surfaced without braces.
+- Optional last step (M-2): `LenientHoppieAPI(HoppieAPI)` overriding `connect` to decode with `errors="replace"`, installed as `cnx._api` in `_open`; a test asserts the attribute exists on `HoppieConnector` so a library upgrade cannot silently disable it.
+
+### `MainWindow`
+
+- `link_callback`: on LOST add SYSTEM row "Connection lost, retrying" and play the sound; on restore "Connection restored" with sound; on `callsign already in use` a SYSTEM row once per episode; on FATAL a dialog "The server rejected the logon code", `polling_controller.stop()`, `weather_monitor.stop()`, `connection_manager.disconnect()`, `cpdlc_session.reset()` (package 3 adds the method; until then the existing fields are cleared inline), menu label back to Connect.
+- `unreadable_callback`: SYSTEM row "Unreadable message from <sender>: <raw>" with the notification sound.
+- Acknowledgement `rate_limit`: `send_acknowledgement` returns `(False, "rate_limit")`; the window schedules one retry with `wx.CallLater(5000, …)`; a second failure shows the existing dialog. Package 4 replaces this with queue pacing.
+
+### `app.py` reporter
+
+`report()` shows its dialog through `wx.CallAfter` on every thread and keeps a
+`_dialog_open` flag; while it is set, further reports are logged only.
+
+### Tests
+
+`FailingConnection` fake with settable `poll()` results; assertions on the
+ladder (20, 60, 120, 300, 300 s), on every status text, on `is_running()` after
+a failed re-verification (still true), on FATAL (timer stopped, `disconnect()`
+called), on `UnreadableMessage` reaching the window, on a callback exception
+not losing the rest of the batch, on the `rate_limit` retry, and on the three
+envelope cases.
+
+---
+
+## Package 3: session and protocol state
+
+**Goal.** The app's idea of who it is talking to matches the network's, across
+handovers, disconnects and reconnects.
+
+### `CpdlcSession` interface additions
+
+```python
+def reset(self) -> None
+    # current_station, pending_logon_*, previous_station(_until) cleared; MIN = 1
+def handle_handover(self, old: str, new: str) -> tuple[bool, str | None]
+    # records previous_station = old, previous_station_until = now + window,
+    # clears current_station, then logon(new); returns logon()'s result
+def is_answerable_sender(self, sender: str) -> bool
+    # current station, or previous station while the window is open
+def handle_logon_rejected(self, station: str, mrn: int | None) -> bool
+    # LOGON REJECTED from the pending station, or UNABLE whose MRN is the pending MIN
+def expire_pending(self, now: float | None = None) -> str | None
+    # returns the station whose pending logon just expired, else None
+```
+
+`logon(station)`: if `current_station` is set, call `logoff()` first (its
+failure is returned to the caller as a warning string but does not abort), then
+restart MIN at 1 and send REQUEST LOGON. `logoff()` and `handle_handover()`
+clear the pending state. `set_callsign()` is replaced by `begin_session(callsign,
+network)`, which calls `reset()` when either differs from the previous session.
+Time comes from `time.monotonic()` with an injectable clock for tests.
+
+### `MessageManager` and `MessageView`
+
+`needs_acknowledgement(message_id, is_answerable)` takes the predicate;
+`MessageView` receives `is_answerable_sender` instead of `get_current_station`.
+
+### `MainWindow._on_message_received`
+
+- The session block runs only for `isinstance(message, CpdlcMessage)` and reads `message.get_message()` and `message.get_mrn()` directly. Telex, progress and ADS-C messages are displayed and nothing else.
+- `LOGON ACCEPTED` matches on prefix; `LOGON REJECTED` and `UNABLE` with the pending MRN go to `handle_logon_rejected` (status "Logon to X rejected.", SYSTEM row).
+- `HANDOVER` calls `handle_handover`; `LOGOFF` from the current station as today.
+- The auto-tune branch runs when `is_answerable_sender(sender)` is true, so the `CONTACT` that follows a handover is tuned.
+- `PollingController(tick_callback=…)` runs at the end of every tick; the window uses it for `expire_pending()` and announces "Logon to X not answered." with a SYSTEM row.
+
+### `MainWindow` connect and disconnect
+
+`on_connect` calls `cpdlc_session.begin_session(callsign, network_type)`.
+`on_disconnect` attempts the LOGOFF, adds "Could not send LOGOFF to X: <reason>"
+if it failed, then always calls `reset()`. `on_close` does the same before
+shutting down.
+
+### Tests
+
+Replace the strict-scoping tests with the window rule. Add the log's handover
+sequence verbatim: `HANDOVER @CZYZ@`, then in one batch `CONTACT TORONTO CENTER
+ON @135.625@.` from KUSA and `LOGON ACCEPTED` from CZYZ — the CONTACT is
+answerable, is tuned, and is no longer answerable once the clock passes the
+window. Reset on disconnect with a failed LOGOFF; no reset on automatic
+reconnection; reset on a different callsign; logon while logged on sends
+`LOGOFF` then `REQUEST LOGON` with MIN 1; rejection and expiry; a telex reading
+`LOGON ACCEPTED` changes nothing.
+
+---
+
+## Package 4: one network worker
+
+**Goal.** The GUI thread never waits on the network, sends are paced and
+serialised, and background results can never touch a dead window.
+
+### `NetworkWorker` (`src/model/network_worker.py`, new)
+
+```python
+@dataclass(order=True)
+class Job:
+    priority: int             # 0 send, 1 connect/poll, 2 inforeq/simbrief/update/simconnect
+    sequence: int             # FIFO within a priority
+    kind: str = field(compare=False)
+    fn: Callable = field(compare=False)
+    on_done: Callable = field(compare=False)
+    generation: int = field(compare=False)
+
+@dataclass
+class JobResult:
+    ok: bool
+    value: object = None
+    error: str | None = None      # HoppieError text or "<ExceptionName>: <text>"
+    job: Job | None = None
+
+class NetworkWorker:
+    def __init__(self, logger, dispatch=wx.CallAfter, start_thread=True,
+                 spacing=None): ...
+    def submit(self, kind, fn, on_done, priority) -> Job
+    def new_generation(self) -> int
+    def run_pending(self) -> None          # test mode: run queued jobs inline
+    def shutdown(self, timeout=2.0) -> None
+```
+
+One daemon thread pops jobs from a `queue.PriorityQueue`. A job whose
+generation is older than the current one is skipped. Before a `send` job the
+worker sleeps until `SEND_SPACING_SECONDS` have passed since the previous send;
+`inforeq` jobs use `INFOREQ_SPACING_SECONDS`. `fn()` runs on the worker; any
+exception is caught and becomes `JobResult(ok=False, error=…)`, with
+non-`HoppieError` exceptions logged with traceback. Results go back through
+`dispatch(on_done, result)` guarded by an alive flag; `dispatch` errors
+(`AssertionError` from a gone `wx.App`, `RuntimeError` from a dead proxy) are
+logged and dropped. Nothing in the worker touches a wx object.
+
+### Callers
+
+- `PollingController` submits `("poll", connection_manager.poll, self._on_poll_result, 1)` per tick and skips a tick while one is in flight; `_on_poll_result` is the existing processing code. The timer stays on the GUI thread.
+- `CpdlcSession.send_*` methods, and likewise `logon`, `logoff` and `handle_handover` from package 3, return `bool` (enqueued or refused by a precondition), build and validate the frame synchronously, consume the MIN at enqueue time (a failed send leaves a gap, which is harmless), and call `on_done(success, text_or_error)` on the GUI thread. Window handlers keep their current success/failure code inside the callback. `send_acknowledgement` loses the `CallLater` retry from package 2: pacing makes `rate_limit` unreachable, and a residual one is reported like any other failure.
+- `on_connect` submits a connect job, closes the dialog at once, shows "Connecting as X…", disables the Connect menu item until the result; on success it runs today's post-connect code, on failure the existing dialog.
+- `WeatherMonitor` drops its thread: a cycle bumps a cycle id and submits one inforeq job per subscription; the cycle is complete when its last job reports; a new cycle's id makes older results ignored. The manual weather request uses the same path, closing the dialog immediately and adding the report or the error when it arrives.
+- `ConnectDialog` and `PDCDialog` take a `fetch_simbrief(on_done)` callable, open immediately with a "Fetching SimBrief flight plan…" label, and fill their fields in `on_done` if `self._alive` (cleared by an overridden `Destroy`).
+- `UpdateChecker` submits its request as a job; the result is handed to the window as `pending_update`, shown only when no dialog is open. The prompt is parented to the main window, says "Open the release page in your browser?", and never closes the app. Runs from source (`not getattr(sys, "frozen", False)`) skip the automatic check.
+- `SimConnectManager.connect()` runs once per network connect as a job. `set_com1_standby_mhz` stays on the GUI thread, checks the return value of `send_event`, and on failure calls `exit()`, drops the object and submits a reconnect job whose callback re-sends the frequency once. `auto_tune_com1` is cached on the window and refreshed when Settings is saved.
+
+### Modal dialogs
+
+```python
+@contextmanager
+def _show_dialog(self, dlg):
+    self._modal_depth += 1
+    try:
+        yield dlg.ShowModal()
+    finally:
+        self._modal_depth -= 1
+        dlg.Destroy()
+        self._flush_deferred()      # pending update prompt, if any
+```
+
+Every handler uses it; `wx.MessageBox` calls go through a `_message_box()`
+helper that counts the same way. A test patches `wx.Dialog.ShowModal` to assert
+the counter is positive whenever it is called.
+
+### Lifecycle
+
+- `install_request_timeout(NETWORK_TIMEOUT)` passes the `(10, 15)` tuple.
+- `on_disconnect` loses `wx.MilliSleep(500)` and the `set_active_polling()` before `stop()`; `worker.new_generation()` drops queued work.
+- `on_close`: `_confirm_exit` checks `event.CanVeto()` and skips the question on a forced close; LOGOFF is submitted at priority 0 and `worker.shutdown(timeout=5)` waits for the queue to drain; then weather monitor, SimConnect, `Skip()`.
+- `app.py`: the `KeyboardInterrupt` branch and the `OnExceptionInMainLoop` override are removed (wx already routes handler exceptions to `sys.excepthook`, and SIGINT is reset by `wx.App`).
+
+### Landing order
+
+Three steps, each leaving the suite green: (1) worker plus poll path plus
+weather; (2) sends and connect through the worker, `CpdlcSession` callback
+signatures; (3) SimBrief, update checker, SimConnect connect, modal counting,
+lifecycle clean-up.
+
+### Tests
+
+The worker is tested with `dispatch=lambda fn, *a: fn(*a)` and
+`start_thread=False`: priority order, FIFO within priority, generation skipping,
+send spacing (with an injected clock and sleep), exception capture, alive-flag
+drop. Each caller's tests drive `run_pending()` and assert the GUI-side effects
+that exist today. Package 1's thread-stub weather tests become worker tests.
+
+---
+
+## Package 5: dialog validation and feedback
+
+- Every getter returns stripped text; `LogonDialog` validates `^[A-Z0-9]{4}$` after upper-casing and `on_logon` drops its duplicate check; `SettingsDialog.get_settings` strips the codes and the SimBrief id.
+- Numeric validation on ASCII digits only (`text.isascii() and re.fullmatch(...)`): altitude `\d{2,3}` zero-padded to three (`FL050`); Mach `\d{2,3}` padded to three; knots `\d{3}`; When-can-we per type with the same rules. Direct-to `[A-Z0-9]{2,7}`, helper text "2-7 letters or digits, e.g. KONOL or 55N020W". The Mach/knots duplicate branch in `SpeedRequestDialog` collapses.
+- `TelexDialog` shows "n / 220 characters" and disables OK over 220 or for non-ASCII text.
+- `on_settings` applies the interval inside the `save_config` success branch; the confirmation reads "Settings saved. The weather interval applies now; logon codes apply to the next connection."
+- `resource_path` uses `os.path.dirname(os.path.abspath(sys.argv[0]))` when not frozen.
+- `message_formatting`: `@@` collapses like a single `@`; `format_list_text` collapses runs of spaces. `MessageView` sets the Sender column to `LIST_AUTOSIZE_USEHEADER` and resizes the Message column on `EVT_SIZE`.
+- `WeatherSubscriptionsDialog` takes an `on_stop(icao, info_type)` callback (the window's toggle helper, which adds the SYSTEM row and status text) and a `subscribe_to_changes(callback)` hook on `WeatherMonitor` to refresh when a subscription is dropped or updated.
+- `frequency_parser`: unit name optional (`(?:.+?\s+)?`), comment corrected; HANDOVER pattern `^HANDOVER\s+@?([A-Z]{4})@?` with trailing text allowed.
+- Tests: per-dialog OK-button tables and getter literals (Telex built with a parent stub); the formatting and parser tables extended.
+
+---
+
+## Package 6: release, packaging, docs, hygiene
+
+- **Version.** `RELEASING.md` documents: run `python update_version.py X.Y.Z`, commit, tag `vX.Y.Z`, push. The release workflow adds a step that fails when `APP_VERSION` in `src/config.py` differs from the tag, and a `test` job the build depends on. `about_dialog` shows "(source)" after the version and the copyright year comes from `datetime.date.today().year`.
+- **Dependencies.** `requirements-build.txt` holds `pyinstaller`; `requirements.txt` pins `SimConnect==0.4.26`; `app.spec` raises `SystemExit("SimConnect.dll not found")` instead of silently omitting it; `.gitignore` gains `installer/` and `.pytest_cache/`; dependabot watches `github-actions`.
+- **Docs.** README: "Python 3.12 or higher", altitude section without the climb/descent bullet, "requested reports arrive without the sound; automatic updates play it", reconnection paragraph describing package 2, tests table from `tests/README.md`; `app.py` docstring names both networks.
+- **Hygiene.** Delete `src/utils/latest_simbrief_ofp.json`; move `src/utils/test_simbrief.py` to `tools/simbrief_probe.py` reading `SIMBRIEF_USERID` from the environment. Remove unused imports (`main_window.py`, `cpdlc_session.py`, `polling_controller.py`), `MessageManager.get_weather_key`, `ConnectionManager.message_callback`, `PollingController.default_poll_interval`, the `send_logoff_message` alias, `MainWindow.get_current_station` (`TelexDialog(parent, recipient)`), the local imports in `_check_first_launch`. Add `_require_logon(action)` next to `_require_connection` and use both in every handler; one `_send_request(text)` helper behind the four request senders. `simbrief.py` logs to `"Sim-CPDLC"`; `setup_logging` adds the console handler only when `sys.stderr` is not `None`; `load_config`/`save_config` log key names only; redacted `HoppieError`s are raised `from None`; `Optional[str]` hints; helper texts use `wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)`; the Connect `RadioBox` gets the label "Network".
+
+---
+
+## Cross-cutting
+
+### Notification policy
+
+| Event | Status bar | SYSTEM row | Sound |
+|---|---|---|---|
+| Uplink received | — | (message row) | yes |
+| Automatic weather change | "New ATIS EGLL information K" | (report row) | yes |
+| Link degraded (1–2 failures) | "Connection problem (n/3) - retrying..." | — | — |
+| Link lost (3+) | "Connection lost - retrying in N s" | "Connection lost, retrying" | yes |
+| Link restored | "Connection restored." | "Connection restored" | yes |
+| Logon code rejected (fatal) | "Disconnected: logon code rejected." | yes, plus dialog | yes |
+| Callsign already in use | (degraded text) | once per episode | — |
+| Unreadable uplink | — | "Unreadable message from X: <raw>" | yes |
+| Send in progress / done | "Sending WILCO…" / cleared | (echo row on success) | — |
+| Send failed | — | — | dialog |
+| Logon rejected / expired | "Logon to X rejected." / "not answered." | yes | — |
+| LOGOFF could not be sent on disconnect | — | yes | — |
+
+### Testing rules
+
+TDD in every package; the suite is green after every commit; package 1's
+fixtures make any network or real-config access a test failure. Each package's
+plan lists its tests before its code.
+
+### Manual acceptance before the next release
+
+Handover followed by a `CONTACT` from the previous station is answerable and
+tuned; unplugging the network for three minutes produces the lost and restored
+announcements and messages resume afterwards; a wrong logon code produces the
+fatal dialog and a Connect label; two acknowledgements sent within five seconds
+on SayIntentions both arrive; File > Connect with a SimBrief id opens the dialog
+at once; the update prompt never closes the app.
+
+## Sequencing and delivery
+
+Packages land in order 1 to 6, one branch and pull request each, and each plan
+is written after the previous package has merged so it builds on merged code.
+Package 4 is the largest and lands in the three steps listed above.
+
+## Risks
+
+- Package 4 changes the `CpdlcSession` send signatures and every handler; the three-step landing keeps each diff reviewable.
+- The 10-minute windows and the back-off ladder are guesses informed by the log; all are constants in `config.py`.
+- The optional decode shim uses the library's private `_api` attribute; its guard test fails loudly on a library change.
+- Modal counting depends on every dialog going through `_show_dialog`; the `ShowModal` assertion test catches a bypass.
+
+## Out of scope
+
+Station-presence pings, a permissive CPDLC parser, MIN wrap at 64, message-log
+eviction (accepted WON'T FIX), other networks, accelerator remapping.

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,6 @@
 # that calls the live SimBrief API, and pytest would otherwise collect it.
 testpaths = tests
 pythonpath = .
+# A test that blocks on a real dialog or a real network call must fail, not
+# hang the run.
+timeout = 60

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 pytest==9.1.1
+pytest-timeout==2.4.0

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,8 @@ window, the automatic weather update logic and the main window wiring. They
 need no network connection, no running simulator and no ACARS logon code, and
 the fixtures in `conftest.py` make sure of it: every test gets a temporary
 config file, outbound requests and browser launches raise, SimBrief lookups
-answer with no flight plan, and `wx.MessageBox` is a recorder.
+answer with no flight plan, and `wx.MessageBox` and `wx.MessageDialog` are
+recorders.
 
 Run them from the repository root:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,8 +1,11 @@
 # Tests
 
-Offline checks for the CPDLC request formats, the automatic weather update
-logic and the main window wiring. They need no network connection, no running
-simulator and no ACARS logon code.
+Offline checks for the CPDLC request formats, the message handling in the
+window, the automatic weather update logic and the main window wiring. They
+need no network connection, no running simulator and no ACARS logon code, and
+the fixtures in `conftest.py` make sure of it: every test gets a temporary
+config file, outbound requests and browser launches raise, SimBrief lookups
+answer with no flight plan, and `wx.MessageBox` is a recorder.
 
 Run them from the repository root:
 
@@ -12,22 +15,33 @@ pytest
 ```
 
 The GUI tests build real wx windows, dialogs and timers, so they need a desktop
-session; CI runs them on Windows for that reason.
+session; CI runs them on Windows for that reason. Each test is limited to 60
+seconds.
+
+Shared test doubles (`uplink`, `FakeConnectionManager`, `FakeSimConnectManager`,
+`make_main_window`, ...) live in `support.py`; import them with
+`from tests.support import ...`.
 
 | File | Covers |
 | --- | --- |
-| `test_acknowledge_path.py` | Responding to an uplink, end to end from the window |
-| `test_connection_manager.py` | The network boundary: errors, timeouts, reconnection |
-| `test_cpdlc_session.py` | Session state and logon acceptance validation |
-| `test_dialogs.py` | The validation each request dialog applies before submitting |
-| `test_downlink_requests.py` | The exact text of every downlink the client can send |
+| `test_acknowledge_path.py` | Responding to an uplink, end to end from the window, down to the frame |
+| `test_config.py` | Reading, writing and clamping the configuration |
+| `test_connection_manager.py` | The network boundary: errors, timeouts, reconnection, the wire packets |
+| `test_cpdlc_session.py` | Session state and logon acceptance validation, including the MRN check |
+| `test_dialogs.py` | The validation the weather request dialog applies before submitting |
+| `test_downlink_requests.py` | The exact text of every downlink the client can send, and every send failure |
+| `test_frequency_parser.py` | Which CONTACT/MONITOR texts tune the standby radio |
+| `test_harness.py` | The hermetic fixtures themselves |
 | `test_logon_status.py` | Logon state as reported to the user |
-| `test_main_window.py` | The real window: menus, handlers, message list, weather toggles |
+| `test_main_window.py` | The real window: menu bindings, message list, weather toggles |
 | `test_main_window_wiring.py` | `_init_ui` alone, on a stripped-down frame |
-| `test_message_manager.py` | Message storage, addressing and response options |
+| `test_message_formatting.py` | Packet prefix stripping and the list and detail text |
+| `test_message_manager.py` | Message storage, addressing and the full response table |
 | `test_message_view.py` | The message list and its response context menu |
 | `test_polling_controller.py` | Which messages speed up polling, and the poll intervals |
+| `test_uplink_handling.py` | HANDOVER, LOGOFF, protocol noise and auto-tune through the window |
 | `test_weather_monitor.py` | Weather change detection and the update timer lifecycle |
+| `test_weather_parsing.py` | The report registry, the ATIS letter and the report formatters |
 
 `test_downlink_requests.py` asserts message text literally, so a change to a
 format shows up there before it reaches the network.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,19 @@
 """Shared fixtures for the sim-cpdlc test suite.
 
 Helpers and test doubles live in tests/support.py; this file holds fixtures
-only.
+only. The autouse fixtures make the suite hermetic: whatever a test builds, it
+cannot read or write the real configuration file, reach the network, call
+SimBrief or block on a message box.
 """
 
 import logging
+import webbrowser
 
 import pytest
+import requests
 import wx
+
+from src import config as config_module
 
 
 @pytest.fixture
@@ -17,6 +23,88 @@ def logger():
     log.handlers = [logging.NullHandler()]
     log.propagate = False
     return log
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(monkeypatch, tmp_path):
+    """Point the configuration file at a per-test temporary path.
+
+    load_config(), save_config() and MainWindow._check_first_launch() all read
+    src.config.CONFIG_FILE at call time, so one patch covers every path that
+    could otherwise touch the developer's real config.json.
+
+    Returns:
+        str: Path of the isolated config file, which may not exist yet.
+    """
+    path = tmp_path / "config.json"
+    monkeypatch.setattr(config_module, "CONFIG_FILE", str(path))
+    return str(path)
+
+
+@pytest.fixture(autouse=True)
+def no_network(monkeypatch):
+    """Refuse every outbound request a test did not explicitly fake.
+
+    Tests that need HTTP install their own fake over these (see serving() in
+    test_connection_manager.py); a test's own monkeypatch runs after this one.
+    """
+
+    def refuse(*args, **kwargs):
+        raise RuntimeError("network access in a test")
+
+    monkeypatch.setattr(requests, "get", refuse)
+    monkeypatch.setattr(requests, "post", refuse)
+    monkeypatch.setattr(webbrowser, "open", refuse)
+
+
+@pytest.fixture(autouse=True)
+def no_simbrief(monkeypatch):
+    """Answer every SimBrief lookup with "no flight plan", recording the ids asked for.
+
+    The Connect and PDC dialogs import get_latest_ofp by name, so the patch
+    lands on each dialog module rather than on src.utils.simbrief.
+
+    Returns:
+        list: The SimBrief user ids the dialogs asked for.
+    """
+    asked = []
+
+    def fake(user_id):
+        asked.append(user_id)
+        return None
+
+    monkeypatch.setattr("src.gui.dialogs.connect_dialog.get_latest_ofp", fake)
+    monkeypatch.setattr("src.gui.dialogs.pdc_dialog.get_latest_ofp", fake)
+    return asked
+
+
+class MessageBoxes:
+    """Records wx.MessageBox calls and answers them without showing anything."""
+
+    def __init__(self):
+        self.calls = []
+        self.answer = wx.YES
+
+    def __call__(self, message, caption="Message", style=wx.OK, *args, **kwargs):
+        self.calls.append((message, caption, style))
+        return self.answer
+
+    @property
+    def captions(self):
+        return [caption for _, caption, _ in self.calls]
+
+
+@pytest.fixture(autouse=True)
+def message_boxes(monkeypatch):
+    """Replace wx.MessageBox with a recorder so no test can block on a modal.
+
+    Every module calls it as wx.MessageBox, so patching the wx module attribute
+    covers them all. Set .answer to wx.NO to take the cancel branch of a
+    confirmation.
+    """
+    recorder = MessageBoxes()
+    monkeypatch.setattr(wx, "MessageBox", recorder)
+    return recorder
 
 
 @pytest.fixture
@@ -33,7 +121,9 @@ def wx_app():
     # monitor, a SimConnect manager and an update checker -- stays alive for
     # the rest of the session.
     wx.SafeYield()
+    leaked = [type(window).__name__ for window in wx.GetTopLevelWindows()]
     app.Destroy()
+    assert leaked == [], f"top-level windows leaked by this test: {leaked}"
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,13 @@
-"""Shared fixtures for the sim-cpdlc test suite."""
+"""Shared fixtures for the sim-cpdlc test suite.
+
+Helpers and test doubles live in tests/support.py; this file holds fixtures
+only.
+"""
 
 import logging
 
 import pytest
 import wx
-from hoppie_connector import CpdlcMessage, CpdlcResponseRequirement as RR
-
-CLIENT_CALLSIGN = "DLH123"
 
 
 @pytest.fixture
@@ -41,75 +42,3 @@ def frame(wx_app):
     frame = wx.Frame(None)
     yield frame
     frame.Destroy()
-
-
-def uplink(sender, min_value, text="CLIMB TO AND MAINTAIN FL360", rr=RR.WILCO_UNABLE):
-    """Build an uplink CpdlcMessage as it would arrive from a station."""
-    return CpdlcMessage(sender, CLIENT_CALLSIGN, min_value, rr, text)
-
-
-class FakeConnectionManager:
-    """Stands in for ConnectionManager, recording frames instead of transmitting.
-
-    ConnectionManager is the network boundary and is injected into CpdlcSession,
-    so this is the intended seam rather than a mock of code under test.
-    """
-
-    def __init__(self, connected=True):
-        self._connected = connected
-        self.sent = []
-        self.info_requests = []
-
-    def is_connected(self):
-        return self._connected
-
-    def send_cpdlc(self, recipient, min_value, response_type, message, mrn=None):
-        self.sent.append((recipient, min_value, response_type, message, mrn))
-
-    def send_info_request(self, info_type, icao):
-        self.info_requests.append((info_type, icao))
-        return f"{icao} REPORT FOR {info_type}"
-
-
-class RecordingMessageView:
-    """Captures the message IDs the window pushes into the list view."""
-
-    def __init__(self):
-        self.added = []
-
-    def add_message(self, message_id):
-        self.added.append(message_id)
-
-
-class FakePollingController:
-    """Records polling-rate changes without owning a wx.Timer."""
-
-    def __init__(self):
-        self.active_calls = 0
-
-    def set_active_polling(self):
-        self.active_calls += 1
-
-
-def make_main_window(logger, cpdlc_session, message_manager):
-    """Build a MainWindow whose wx.Frame half is never initialised.
-
-    MainWindow.__init__ opens dialogs, loads sounds and starts an update check,
-    none of which a unit test should trigger. Allocating the instance and wiring
-    only the collaborators the message path touches lets the real
-    _on_message_received / _on_acknowledge_message code run unmodified.
-    """
-    from src.gui.main_window import MainWindow
-
-    window = MainWindow.__new__(MainWindow)
-    window.logger = logger
-    window.cpdlc_session = cpdlc_session
-    window.message_manager = message_manager
-    window.message_view = RecordingMessageView()
-    window.polling_controller = FakePollingController()
-    window.new_message_sound = None
-    window.status_texts = []
-    # Instance attribute shadows wx.Frame.SetStatusText, which would need a
-    # live C++ frame behind it.
-    window.SetStatusText = window.status_texts.append
-    return window

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import pytest
 import requests
 import wx
 
-from tests.support import MessageBoxes
+from tests.support import MessageBoxes, MessageDialogs
 from src import config as config_module
 
 
@@ -55,6 +55,8 @@ def no_network(monkeypatch):
 
     monkeypatch.setattr(requests, "get", refuse)
     monkeypatch.setattr(requests, "post", refuse)
+    monkeypatch.setattr(requests, "request", refuse)
+    monkeypatch.setattr(requests.Session, "request", refuse)
     monkeypatch.setattr(webbrowser, "open", refuse)
 
 
@@ -89,6 +91,18 @@ def message_boxes(monkeypatch):
     """
     recorder = MessageBoxes()
     monkeypatch.setattr(wx, "MessageBox", recorder)
+    return recorder
+
+
+@pytest.fixture(autouse=True)
+def message_dialogs(monkeypatch):
+    """Replace wx.MessageDialog with a recorder so no test can block on one.
+
+    _check_first_launch() opens a MessageDialog whenever the config file is
+    missing, which is the default state of the isolated config.
+    """
+    recorder = MessageDialogs()
+    monkeypatch.setattr(wx, "MessageDialog", recorder)
     return recorder
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import pytest
 import requests
 import wx
 
+from tests.support import MessageBoxes
 from src import config as config_module
 
 
@@ -76,22 +77,6 @@ def no_simbrief(monkeypatch):
     monkeypatch.setattr("src.gui.dialogs.connect_dialog.get_latest_ofp", fake)
     monkeypatch.setattr("src.gui.dialogs.pdc_dialog.get_latest_ofp", fake)
     return asked
-
-
-class MessageBoxes:
-    """Records wx.MessageBox calls and answers them without showing anything."""
-
-    def __init__(self):
-        self.calls = []
-        self.answer = wx.YES
-
-    def __call__(self, message, caption="Message", style=wx.OK, *args, **kwargs):
-        self.calls.append((message, caption, style))
-        return self.answer
-
-    @property
-    def captions(self):
-        return [caption for _, caption, _ in self.calls]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/support.py
+++ b/tests/support.py
@@ -4,6 +4,8 @@ These are helpers, not fixtures: import them explicitly with
 `from tests.support import ...`. Fixtures live in conftest.py.
 """
 
+import wx
+
 from hoppie_connector import CpdlcMessage, CpdlcResponseRequirement as RR
 
 from src.config import DEFAULT_CONFIG, save_config
@@ -106,6 +108,22 @@ class FakeSimConnectManager:
     def set_com1_standby_mhz(self, frequency_mhz):
         self.tuned.append(frequency_mhz)
         return self.result
+
+
+class MessageBoxes:
+    """Records wx.MessageBox calls and answers them without showing anything."""
+
+    def __init__(self):
+        self.calls = []
+        self.answer = wx.YES
+
+    def __call__(self, message, caption="Message", style=wx.OK, *args, **kwargs):
+        self.calls.append((message, caption, style))
+        return self.answer
+
+    @property
+    def captions(self):
+        return [caption for _, caption, _ in self.calls]
 
 
 def make_main_window(logger, cpdlc_session, message_manager, config=None, simconnect=None):

--- a/tests/support.py
+++ b/tests/support.py
@@ -1,0 +1,147 @@
+"""Shared test doubles and builders for the sim-cpdlc test suite.
+
+These are helpers, not fixtures: import them explicitly with
+`from tests.support import ...`. Fixtures live in conftest.py.
+"""
+
+from hoppie_connector import CpdlcMessage, CpdlcResponseRequirement as RR
+
+from src.config import DEFAULT_CONFIG, save_config
+
+CLIENT_CALLSIGN = "DLH123"
+
+
+def uplink(
+    sender, min_value, text="CLIMB TO AND MAINTAIN FL360", rr=RR.WILCO_UNABLE, mrn=None
+):
+    """Build an uplink CpdlcMessage as it would arrive from a station.
+
+    Args:
+        sender: Station sending the message
+        min_value: The station's own message number (MIN)
+        text: Message element text
+        rr: Response requirement
+        mrn: Message reference number, the MIN of our message this one
+            answers. Every real LOGON ACCEPTED carries one.
+    """
+    return CpdlcMessage(sender, CLIENT_CALLSIGN, min_value, rr, text, mrn)
+
+
+class FakeConnectionManager:
+    """Stands in for ConnectionManager, recording frames instead of transmitting.
+
+    ConnectionManager is the network boundary and is injected into CpdlcSession,
+    so this is the intended seam rather than a mock of code under test.
+
+    Args:
+        connected: What is_connected() reports
+        raise_with: An exception every send raises instead of recording, for
+            exercising the failure paths
+    """
+
+    def __init__(self, connected=True, raise_with=None):
+        self._connected = connected
+        self.raise_with = raise_with
+        self.sent = []
+        self.telexes = []
+        self.info_requests = []
+
+    def is_connected(self):
+        return self._connected
+
+    def send_cpdlc(self, recipient, min_value, response_type, message, mrn=None):
+        if self.raise_with is not None:
+            raise self.raise_with
+        self.sent.append((recipient, min_value, response_type, message, mrn))
+
+    def send_telex(self, recipient, message):
+        if self.raise_with is not None:
+            raise self.raise_with
+        self.telexes.append((recipient, message))
+
+    def send_info_request(self, info_type, icao):
+        if self.raise_with is not None:
+            raise self.raise_with
+        self.info_requests.append((info_type, icao))
+        return f"{icao} REPORT FOR {info_type}"
+
+
+class RecordingMessageView:
+    """Captures the message IDs the window pushes into the list view."""
+
+    def __init__(self):
+        self.added = []
+
+    def add_message(self, message_id):
+        self.added.append(message_id)
+
+
+class FakePollingController:
+    """Records polling-rate changes without owning a wx.Timer."""
+
+    def __init__(self):
+        self.active_calls = 0
+
+    def set_active_polling(self):
+        self.active_calls += 1
+
+
+class FakeSimConnectManager:
+    """Records the frequencies the window tries to tune, never touching a simulator.
+
+    Args:
+        result: What connect() and set_com1_standby_mhz() report back
+    """
+
+    def __init__(self, result=True):
+        self.result = result
+        self.tuned = []
+
+    def connect(self):
+        return self.result
+
+    def disconnect(self):
+        pass
+
+    def set_com1_standby_mhz(self, frequency_mhz):
+        self.tuned.append(frequency_mhz)
+        return self.result
+
+
+def make_main_window(logger, cpdlc_session, message_manager, config=None, simconnect=None):
+    """Build a MainWindow whose wx.Frame half is never initialised.
+
+    MainWindow.__init__ opens dialogs, loads sounds and starts an update check,
+    none of which a unit test should trigger. Allocating the instance and wiring
+    only the collaborators the message path touches lets the real
+    _on_message_received / _on_acknowledge_message code run unmodified.
+
+    Args:
+        logger: Test logger
+        cpdlc_session: The CpdlcSession the window should drive
+        message_manager: The MessageManager the window should fill
+        config: Overrides written to the (isolated) config file, so the
+            window's own load_config() calls see them. None leaves the
+            defaults in place.
+        simconnect: A FakeSimConnectManager; a fresh one when None
+    """
+    from src.gui.main_window import MainWindow
+
+    if config is not None:
+        assert save_config({**DEFAULT_CONFIG, **config}), "could not write test config"
+
+    window = MainWindow.__new__(MainWindow)
+    window.logger = logger
+    window.cpdlc_session = cpdlc_session
+    window.message_manager = message_manager
+    window.message_view = RecordingMessageView()
+    window.polling_controller = FakePollingController()
+    window.simconnect_manager = (
+        simconnect if simconnect is not None else FakeSimConnectManager()
+    )
+    window.new_message_sound = None
+    window.status_texts = []
+    # Instance attribute shadows wx.Frame.SetStatusText, which would need a
+    # live C++ frame behind it.
+    window.SetStatusText = window.status_texts.append
+    return window

--- a/tests/support.py
+++ b/tests/support.py
@@ -126,6 +126,36 @@ class MessageBoxes:
         return [caption for _, caption, _ in self.calls]
 
 
+class MessageDialogs:
+    """Stands in for wx.MessageDialog: records the request, answers without showing.
+
+    The default answer is wx.ID_NO because the first-launch prompt reacts to
+    ID_YES by scheduling the real Settings dialog through wx.CallAfter.
+    """
+
+    class _Dialog:
+        def __init__(self, recorder):
+            self._recorder = recorder
+
+        def ShowModal(self):
+            return self._recorder.answer
+
+        def Destroy(self):
+            return True
+
+    def __init__(self):
+        self.calls = []
+        self.answer = wx.ID_NO
+
+    def __call__(self, parent, message, caption="Message", style=wx.OK, *args, **kwargs):
+        self.calls.append((message, caption, style))
+        return self._Dialog(self)
+
+    @property
+    def captions(self):
+        return [caption for _, caption, _ in self.calls]
+
+
 def make_main_window(logger, cpdlc_session, message_manager, config=None, simconnect=None):
     """Build a MainWindow whose wx.Frame half is never initialised.
 

--- a/tests/test_acknowledge_path.py
+++ b/tests/test_acknowledge_path.py
@@ -1,5 +1,7 @@
 """End-to-end tests for the acknowledgement path through MainWindow."""
 
+from hoppie_connector import CpdlcResponseRequirement as RR
+
 from tests.support import FakeConnectionManager, make_main_window, uplink
 
 from src.model.cpdlc_session import CpdlcSession
@@ -18,14 +20,30 @@ def build(logger):
     return window, manager, connection
 
 
-def test_wilco_is_sent_with_the_senders_own_min_as_mrn(logger):
+def test_wilco_is_a_complete_response_frame(logger):
+    """Recipient, own MIN, response requirement "N", text and the uplink's MIN
+    as MRN. TODOS item 21: acknowledgements once went out as "NE", which some
+    ATC clients ignore, and nothing asserted the requirement."""
     window, manager, connection = build(logger)
     message_id = manager.add_message(uplink(STATION, 53))
 
     window._on_acknowledge_message(message_id, "WILCO")
 
-    recipient, _own_min, _rr, text, mrn = connection.sent[-1]
-    assert (recipient, text, mrn) == (STATION, "WILCO", 53)
+    assert connection.sent == [(STATION, 1, RR.NO.value, "WILCO", 53)]
+
+
+def test_each_acknowledgement_uses_the_next_own_min(logger):
+    window, manager, connection = build(logger)
+    first = manager.add_message(uplink(STATION, 53))
+    second = manager.add_message(uplink(STATION, 54, "DESCEND TO AND MAINTAIN FL240"))
+
+    window._on_acknowledge_message(first, "WILCO")
+    window._on_acknowledge_message(second, "UNABLE")
+
+    assert [(frame[1], frame[3], frame[4]) for frame in connection.sent] == [
+        (1, "WILCO", 53),
+        (2, "UNABLE", 54),
+    ]
 
 
 def test_wilco_retires_the_message(logger):

--- a/tests/test_acknowledge_path.py
+++ b/tests/test_acknowledge_path.py
@@ -1,6 +1,6 @@
 """End-to-end tests for the acknowledgement path through MainWindow."""
 
-from conftest import FakeConnectionManager, make_main_window, uplink
+from tests.support import FakeConnectionManager, make_main_window, uplink
 
 from src.model.cpdlc_session import CpdlcSession
 from src.model.message_manager import MessageManager

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,10 +4,16 @@ load_config fills in missing keys but validates neither type nor range, so a
 hand-edited or downgrade-written file reaches the application as-is.
 """
 
+import os
+from pathlib import Path
+
 from src.config import (
+    DEFAULT_CONFIG,
     DEFAULT_WEATHER_INTERVAL_MINUTES,
     MAX_WEATHER_INTERVAL_MINUTES,
     MIN_WEATHER_INTERVAL_MINUTES,
+    load_config,
+    save_config,
     weather_interval_minutes,
 )
 
@@ -41,3 +47,55 @@ def test_a_non_numeric_interval_falls_back_to_the_default():
         assert weather_interval_minutes({"weather_update_interval": value}) == (
             DEFAULT_WEATHER_INTERVAL_MINUTES
         ), value
+
+
+# --- reading and writing the file ---------------------------------------------
+
+
+def test_a_missing_file_yields_a_fresh_copy_of_the_defaults():
+    loaded = load_config()
+
+    assert loaded == DEFAULT_CONFIG
+    assert loaded is not DEFAULT_CONFIG
+
+
+def test_missing_keys_are_filled_in_and_present_ones_kept(isolated_config):
+    Path(isolated_config).write_text('{"hoppie_logon_code": "ABC"}')
+
+    loaded = load_config()
+
+    assert loaded["hoppie_logon_code"] == "ABC"
+    assert set(loaded) == set(DEFAULT_CONFIG)
+
+
+def test_invalid_json_yields_the_defaults(isolated_config):
+    Path(isolated_config).write_text("{not json")
+
+    assert load_config() == DEFAULT_CONFIG
+
+
+def test_only_a_mapping_can_be_saved():
+    assert save_config("nope") is False
+
+
+def test_a_saved_config_round_trips():
+    assert save_config({**DEFAULT_CONFIG, "simbrief_userid": "42"}) is True
+
+    assert load_config()["simbrief_userid"] == "42"
+
+
+def test_a_failed_write_leaves_the_previous_file_and_no_temp_file_behind(
+    isolated_config, monkeypatch
+):
+    """TODOS item 5: the write is atomic. A PermissionError from os.replace is
+    what Windows raises when the file is open elsewhere."""
+    save_config({**DEFAULT_CONFIG, "simbrief_userid": "before"})
+
+    def refuse(src, dst):
+        raise PermissionError(13, "file in use", dst)
+
+    monkeypatch.setattr(os, "replace", refuse)
+
+    assert save_config({**DEFAULT_CONFIG, "simbrief_userid": "after"}) is False
+    assert load_config()["simbrief_userid"] == "before"
+    assert [path.name for path in Path(isolated_config).parent.iterdir()] == ["config.json"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,7 +52,7 @@ def test_a_non_numeric_interval_falls_back_to_the_default():
 # --- reading and writing the file ---------------------------------------------
 
 
-def test_a_missing_file_yields_a_fresh_copy_of_the_defaults():
+def test_a_missing_file_yields_a_fresh_copy_of_the_defaults(isolated_config):
     loaded = load_config()
 
     assert loaded == DEFAULT_CONFIG
@@ -74,11 +74,11 @@ def test_invalid_json_yields_the_defaults(isolated_config):
     assert load_config() == DEFAULT_CONFIG
 
 
-def test_only_a_mapping_can_be_saved():
+def test_only_a_mapping_can_be_saved(isolated_config):
     assert save_config("nope") is False
 
 
-def test_a_saved_config_round_trips():
+def test_a_saved_config_round_trips(isolated_config):
     assert save_config({**DEFAULT_CONFIG, "simbrief_userid": "42"}) is True
 
     assert load_config()["simbrief_userid"] == "42"

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -412,26 +412,31 @@ def test_install_request_timeout_supplies_a_default(monkeypatch):
     sock.settimeout(None) when given no timeout."""
     seen = {}
 
-    def _get(url, **kwargs):
+    def _request(url, **kwargs):
         seen.update(kwargs)
         return FakeResponse()
 
-    monkeypatch.setattr(requests, "get", _get)
+    monkeypatch.setattr(requests, "get", _request)
+    monkeypatch.setattr(requests, "post", _request)
     install_request_timeout(7)
 
     requests.get("https://example.invalid/")
+    assert seen["timeout"] == 7
 
+    seen.clear()
+    requests.post("https://example.invalid/")
     assert seen["timeout"] == 7
 
 
 def test_an_explicit_timeout_still_wins(monkeypatch):
     seen = {}
 
-    def _get(url, **kwargs):
+    def _request(url, **kwargs):
         seen.update(kwargs)
         return FakeResponse()
 
-    monkeypatch.setattr(requests, "get", _get)
+    monkeypatch.setattr(requests, "get", _request)
+    monkeypatch.setattr(requests, "post", _request)
     install_request_timeout(7)
 
     requests.get("https://example.invalid/", timeout=1)

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -14,7 +14,7 @@ import logging
 
 import pytest
 import requests
-from hoppie_connector import HoppieConnector, HoppieError
+from hoppie_connector import CpdlcResponseRequirement as RR, HoppieConnector, HoppieError
 
 from src.config import HOPPIE_API_URL, SAYINTENTIONS_API_URL
 from src.model.connection_manager import (
@@ -293,6 +293,24 @@ def test_a_rejected_message_is_not_counted_as_a_link_failure(logger, monkeypatch
 
     assert cm.send_failures == 0
     assert cm.should_attempt_reconnection() is False
+
+
+def test_an_acknowledgement_is_transmitted_as_data2_min_mrn_n_text(logger, monkeypatch):
+    """The literal packet the station's client parses. Built by the real
+    hoppie_connector, captured at the HTTP boundary."""
+    seen = {}
+
+    def _get(url, params=None, **kwargs):
+        seen.update(params or {})
+        return FakeResponse("ok")
+
+    cm = connected(logger, monkeypatch)
+    monkeypatch.setattr(requests, "get", _get)
+
+    cm.send_cpdlc("LSAG", 1, RR.NO.value, "WILCO", mrn=53)
+
+    assert seen["packet"] == "/data2/1/53/N/WILCO"
+    assert (seen["to"], seen["type"], seen["from"]) == ("LSAG", "cpdlc", "DLH123")
 
 
 # --- session state ------------------------------------------------------------

--- a/tests/test_cpdlc_session.py
+++ b/tests/test_cpdlc_session.py
@@ -47,3 +47,15 @@ def test_logon_accepted_with_invalid_station_name_is_rejected(logger):
 
     assert accepted is False
     assert session.get_current_station() == ""
+
+
+def test_logon_accepted_with_a_different_mrn_is_rejected(logger):
+    """TODOS item 24: the MRN must reference our REQUEST LOGON, which always
+    carries MIN 1 because logon() restarts the counter."""
+    session = CpdlcSession(logger, FakeConnectionManager())
+    session.logon("EDDF")
+
+    accepted = session.handle_logon_accepted("EDDF", mrn=2)
+
+    assert accepted is False
+    assert session.get_current_station() == ""

--- a/tests/test_cpdlc_session.py
+++ b/tests/test_cpdlc_session.py
@@ -1,6 +1,6 @@
 """Tests for CPDLC session state, especially logon acceptance validation."""
 
-from conftest import FakeConnectionManager
+from tests.support import FakeConnectionManager
 from src.model.cpdlc_session import CpdlcSession
 
 

--- a/tests/test_downlink_requests.py
+++ b/tests/test_downlink_requests.py
@@ -7,7 +7,7 @@ the network.
 
 import pytest
 
-from conftest import FakeConnectionManager
+from tests.support import FakeConnectionManager
 from src.model.cpdlc_elements import REASON_AIRCRAFT_PERFORMANCE, REASON_WEATHER
 from src.model.cpdlc_session import CpdlcSession
 

--- a/tests/test_downlink_requests.py
+++ b/tests/test_downlink_requests.py
@@ -6,6 +6,7 @@ the network.
 """
 
 import pytest
+from hoppie_connector import HoppieError
 
 from tests.support import FakeConnectionManager
 from src.model.cpdlc_elements import REASON_AIRCRAFT_PERFORMANCE, REASON_WEATHER
@@ -84,3 +85,98 @@ def test_a_weather_reason_is_unchanged(session):
     _, text = session.send_direct_request("MALOT", REASON_WEATHER)
 
     assert text == "REQUEST DIRECT TO MALOT DUE TO WEATHER"
+
+
+# --- the remaining downlinks --------------------------------------------------
+
+
+def test_a_logon_request_uses_min_one_and_expects_an_answer(make_session):
+    session = make_session(station="")
+
+    assert session.logon("EGGX") == (True, "REQUEST LOGON")
+    assert session.connection_manager.sent == [("EGGX", 1, "Y", "REQUEST LOGON", None)]
+    assert (session.pending_logon_station, session.pending_logon_min) == ("EGGX", 1)
+
+
+def test_a_logoff_needs_no_response_and_clears_the_station(session):
+    assert session.logoff() == (True, "LOGOFF")
+    assert session.connection_manager.sent == [(STATION, 1, "NE", "LOGOFF", None)]
+    assert session.get_current_station() == ""
+
+
+@pytest.mark.parametrize(
+    "speed, is_mach, reason, expected",
+    [
+        ("082", True, None, "REQUEST M082"),
+        ("300", False, None, "REQUEST 300K"),
+        ("078", True, REASON_WEATHER, "REQUEST M078 DUE TO WEATHER"),
+    ],
+    ids=["mach", "knots", "mach-with-reason"],
+)
+def test_a_speed_request_names_mach_or_knots(session, speed, is_mach, reason, expected):
+    assert session.send_speed_request(speed, is_mach, reason) == (True, expected)
+
+
+def test_a_when_can_we_expect_inquiry_is_sent_verbatim(session):
+    text = "WHEN CAN WE EXPECT HIGHER LEVEL"
+
+    assert session.send_when_can_we_expect(text) == (True, text)
+
+
+def test_every_request_goes_to_the_current_station_expecting_an_answer(session):
+    session.send_altitude_change_request("FL350")
+    session.send_direct_request("MALOT")
+    session.send_speed_request("082", True)
+    session.send_when_can_we_expect("WHEN CAN WE EXPECT LOWER LEVEL")
+
+    frames = session.connection_manager.sent
+    assert [frame[0] for frame in frames] == [STATION] * 4
+    assert [frame[2] for frame in frames] == ["Y"] * 4
+    assert [frame[1] for frame in frames] == [1, 2, 3, 4]
+
+
+def test_a_telex_goes_to_its_recipient_unchanged(session):
+    assert session.send_telex("EDDF", "HELLO THERE") == (True, "HELLO THERE")
+    assert session.connection_manager.telexes == [("EDDF", "HELLO THERE")]
+
+
+def test_a_pdc_request_is_a_telex_to_the_departure_airport(session):
+    ok, text = session.send_pdc_request("EGLL", "LIMC", "A339", "521", "K")
+
+    assert ok is True
+    assert text == "REQUEST PREDEP CLEARANCE BAW123 A339 TO LIMC AT EGLL STAND 521 ATIS K"
+    assert session.connection_manager.telexes == [("EGLL", text)]
+
+
+def test_a_pdc_request_needs_a_callsign(make_session):
+    session = make_session()
+    session.set_callsign("")
+
+    assert session.send_pdc_request("EGLL", "LIMC", "A339", "521", "K") == (False, None)
+
+
+# --- failure paths ------------------------------------------------------------
+
+SENDS = [
+    ("logon", lambda s: s.logon("EGGX")),
+    ("logoff", lambda s: s.logoff()),
+    ("altitude", lambda s: s.send_altitude_change_request("FL350")),
+    ("direct", lambda s: s.send_direct_request("MALOT")),
+    ("speed", lambda s: s.send_speed_request("082", True)),
+    ("when-can-we", lambda s: s.send_when_can_we_expect("WHEN CAN WE EXPECT HIGHER LEVEL")),
+    ("acknowledgement", lambda s: s.send_acknowledgement(STATION, 7, "WILCO")),
+    ("telex", lambda s: s.send_telex("EDDF", "HELLO")),
+    ("pdc", lambda s: s.send_pdc_request("EGLL", "LIMC", "A339", "521", "K")),
+]
+
+
+@pytest.mark.parametrize("send", [case[1] for case in SENDS], ids=[case[0] for case in SENDS])
+def test_a_transmission_failure_is_reported_and_consumes_no_min(logger, send):
+    """The error text reaches the dialog, and the MIN is not spent, so the
+    next successful send does not leave a gap the station has to explain."""
+    session = CpdlcSession(logger, FakeConnectionManager(raise_with=HoppieError("boom")))
+    session.set_callsign("BAW123")
+    session.current_station = STATION
+
+    assert send(session) == (False, "boom")
+    assert session.cpdlc_min_counter == 1

--- a/tests/test_frequency_parser.py
+++ b/tests/test_frequency_parser.py
@@ -1,0 +1,31 @@
+"""What extract_contact_frequency tunes, on the texts the networks send.
+
+Texts are given as the window sees them: after "@" separators have been
+turned into spaces and whitespace collapsed.
+"""
+
+import pytest
+
+from src.utils.frequency_parser import extract_contact_frequency
+
+CASES = [
+    ("CONTACT MAASTRICHT 132.850", 132.85),
+    ("CONTACT MARSEILLE CONTROL ON 133.325 .", 133.325),
+    ("CONTACT MAASTRICHT ON 132.855 MHZ", 132.855),
+    ("MONITOR UNICOM 122.8", 122.8),
+    ("AT KONOL CONTACT LONDON CONTROL 127.425", 127.425),
+    ("CONTACT MAASTRICHT 132.850 OR 121.500", 132.85),
+    ("CONTACT EDDF_TWR 118.700", 118.7),
+    ("CONTACT MAASTRICHT\n132.850", 132.85),
+    ("CONTACT LOWER LIMIT 118.000", 118.0),
+    ("CONTACT UPPER LIMIT 136.990", 136.99),
+    ("CLIMB TO FL350 REPORT LEVEL", None),
+    ("CONTACT RHEIN RADAR 136.995", None),
+    ("CONTACT LANGEN RADAR 117.950", None),
+    ("CONTACT UPPER LIMIT 137.000", None),
+]
+
+
+@pytest.mark.parametrize("text, expected", CASES, ids=[case[0][:32] for case in CASES])
+def test_the_frequency_read_from_a_contact_or_monitor_instruction(text, expected):
+    assert extract_contact_frequency(text) == expected

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1,0 +1,61 @@
+"""The hermetic fixtures: nothing a test builds may reach outside the test.
+
+Every fixture checked here is autouse, so these tests document guarantees the
+whole suite relies on.
+"""
+
+import webbrowser
+from pathlib import Path
+
+import pytest
+import requests
+import wx
+
+from src import config as config_module
+from src.config import DEFAULT_CONFIG, load_config, save_config
+from src.gui.dialogs import ConnectDialog
+
+
+def test_the_config_file_is_a_temporary_one(isolated_config, tmp_path):
+    assert Path(config_module.CONFIG_FILE) == tmp_path / "config.json"
+    assert Path(isolated_config) == tmp_path / "config.json"
+
+
+def test_saving_the_config_writes_only_the_temporary_file(isolated_config):
+    assert save_config({**DEFAULT_CONFIG, "simbrief_userid": "42"}) is True
+
+    assert Path(isolated_config).exists()
+    assert load_config()["simbrief_userid"] == "42"
+
+
+def test_network_access_is_refused():
+    with pytest.raises(RuntimeError, match="network access in a test"):
+        requests.get("https://example.invalid/")
+    with pytest.raises(RuntimeError, match="network access in a test"):
+        requests.post("https://example.invalid/")
+
+
+def test_opening_a_browser_is_refused():
+    with pytest.raises(RuntimeError, match="network access in a test"):
+        webbrowser.open("https://example.invalid/")
+
+
+def test_message_boxes_are_recorded_and_answered_without_showing(message_boxes):
+    message_boxes.answer = wx.NO
+
+    assert wx.MessageBox("Sure?", "Confirm", wx.YES_NO) == wx.NO
+    assert message_boxes.calls == [("Sure?", "Confirm", wx.YES_NO)]
+    assert message_boxes.captions == ["Confirm"]
+
+
+def test_the_connect_dialog_never_reaches_simbrief(frame, no_simbrief, message_boxes):
+    """With a SimBrief id configured the dialog fetches the flight plan in its
+    constructor and warns when that fails; both must stay inside the test."""
+    save_config({**DEFAULT_CONFIG, "simbrief_userid": "189007"})
+
+    dialog = ConnectDialog(frame)
+    try:
+        assert no_simbrief == ["189007"]
+        assert message_boxes.captions == ["SimBrief"]
+    finally:
+        dialog.Destroy()

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -33,6 +33,10 @@ def test_network_access_is_refused():
         requests.get("https://example.invalid/")
     with pytest.raises(RuntimeError, match="network access in a test"):
         requests.post("https://example.invalid/")
+    with pytest.raises(RuntimeError, match="network access in a test"):
+        requests.request("GET", "https://example.invalid/")
+    with pytest.raises(RuntimeError, match="network access in a test"):
+        requests.Session().get("https://example.invalid/")
 
 
 def test_opening_a_browser_is_refused():
@@ -59,3 +63,19 @@ def test_the_connect_dialog_never_reaches_simbrief(frame, no_simbrief, message_b
         assert message_boxes.captions == ["SimBrief"]
     finally:
         dialog.Destroy()
+
+
+def test_a_first_launch_asks_through_the_recorder_not_a_real_dialog(
+    logger, wx_app, isolated_config, message_dialogs
+):
+    """With no config file, MainWindow.__init__ writes the defaults and asks
+    whether to set them up; both must stay inside the test."""
+    import src.gui.main_window as mw
+
+    window = mw.MainWindow(None, "Sim-CPDLC test", logger)
+    try:
+        assert message_dialogs.captions == ["Welcome to Sim-CPDLC"]
+        assert Path(isolated_config).exists()
+    finally:
+        window.weather_monitor.shutdown()
+        window.Destroy()

--- a/tests/test_logon_status.py
+++ b/tests/test_logon_status.py
@@ -13,7 +13,9 @@ from src.model.message_manager import MessageManager
 
 
 def _logon_accepted_from(station, mrn):
-    return uplink(station, mrn, text="LOGON ACCEPTED", rr=RR.NOT_REQUIRED)
+    """A real acceptance: the station's own MIN 1, referencing our MIN as MRN.
+    All 388 LOGON ACCEPTED uplinks in six months of logs carried an MRN."""
+    return uplink(station, 1, text="LOGON ACCEPTED", rr=RR.NOT_REQUIRED, mrn=mrn)
 
 
 def test_status_bar_is_silent_when_logon_acceptance_is_rejected(logger):
@@ -37,3 +39,14 @@ def test_status_bar_reports_an_accepted_logon(logger):
 
     assert window.status_texts == ["Logged on to EDDF."]
     assert session.get_current_station() == "EDDF"
+
+
+def test_status_bar_is_silent_when_the_mrn_does_not_match(logger):
+    session = CpdlcSession(logger, FakeConnectionManager())
+    session.logon("EDDF")
+    window = make_main_window(logger, session, MessageManager(logger))
+
+    window._on_message_received(_logon_accepted_from("EDDF", 2))
+
+    assert window.status_texts == []
+    assert session.get_current_station() == ""

--- a/tests/test_logon_status.py
+++ b/tests/test_logon_status.py
@@ -5,7 +5,7 @@ with NVDA+End, so a false 'Logged on to X' is the one message a blind pilot
 cannot cross-check.
 """
 
-from conftest import FakeConnectionManager, make_main_window, uplink
+from tests.support import FakeConnectionManager, make_main_window, uplink
 from hoppie_connector import CpdlcResponseRequirement as RR
 
 from src.model.cpdlc_session import CpdlcSession

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -17,8 +17,7 @@ from src.config import DEFAULT_CONFIG, save_config
 from src.gui.dialogs import WeatherDialog
 from src.model.message_manager import WeatherReport
 from src.model.weather_monitor import WeatherSubscription
-
-MENU_TITLES = ["File", "Requests"]
+from tests.support import FakeSimConnectManager
 
 # Which handler each menu item must fire. Every handler is replaced on the
 # class before the window is built, so the Bind() calls in _init_menu pick up
@@ -45,6 +44,8 @@ MENU_BINDINGS = {
     },
 }
 
+MENU_TITLES = list(MENU_BINDINGS)
+
 
 @pytest.fixture
 def build_window(logger, wx_app, isolated_config, message_boxes):
@@ -57,9 +58,15 @@ def build_window(logger, wx_app, isolated_config, message_boxes):
     built = []
 
     def build():
+        # Writing the config file first keeps _check_first_launch() from
+        # asking anything at all; the message_dialogs recorder is the safety
+        # net if that ever stops being true.
         assert save_config({**DEFAULT_CONFIG, "auto_check_updates": False})
         window = mw.MainWindow(None, "Sim-CPDLC test", logger)
         window.Hide()
+        # A real SimConnectManager would try to reach a running MSFS; swap in
+        # the fake so a CONTACT uplink through this window tunes nothing.
+        window.simconnect_manager = FakeSimConnectManager()
         built.append(window)
         return window
 
@@ -102,18 +109,7 @@ def test_the_requests_menu_carries_every_request(window):
 
     labels = [item.GetItemLabelText() for item in requests.GetMenuItems()]
 
-    assert labels == [
-        "PDC",
-        "Logon",
-        "Logoff",
-        "Altitude change",
-        "Direct to",
-        "Speed change",
-        "When can we expect",
-        "Telex message",
-        "ATIS and Weather request",
-        "Automatic weather updates",
-    ]
+    assert labels == list(MENU_BINDINGS["Requests"])
 
 
 def _mnemonic(label):
@@ -216,6 +212,11 @@ def test_every_menu_item_fires_its_own_handler(build_window, monkeypatch):
 def test_a_request_needing_a_connection_is_refused_and_the_user_is_told(window, message_boxes):
     assert window._require_connection("test") is False
     assert message_boxes.captions == ["Not Connected"]
+
+
+def test_the_real_window_never_reaches_the_simulator(window):
+    """A CONTACT uplink through this fixture must tune the fake, not MSFS."""
+    assert isinstance(window.simconnect_manager, FakeSimConnectManager)
 
 
 # --- the message list ---------------------------------------------------------

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -12,7 +12,7 @@ stripped-down frame; this builds the whole window.
 import pytest
 
 import src.gui.main_window as mw
-from src.config import DEFAULT_CONFIG
+from src.config import DEFAULT_CONFIG, save_config
 from src.gui.dialogs import WeatherDialog
 from src.model.message_manager import WeatherReport
 from src.model.weather_monitor import WeatherSubscription
@@ -41,34 +41,32 @@ MENU_HANDLERS = [
 
 
 @pytest.fixture
-def window(logger, wx_app, monkeypatch):
-    """The real window, kept offline and non-modal.
+def build_window(logger, wx_app, isolated_config, message_boxes):
+    """A factory for the real window, kept offline and non-modal.
 
-    Three things in __init__ would otherwise stop a test run dead:
-
-    - _check_first_launch() opens a welcome dialog and blocks on ShowModal
-      whenever no config file exists, which is the case on any CI runner and
-      any fresh machine. It also writes a config file into the real user data
-      directory, which a test has no business doing.
-    - the update check reaches the network.
-    - a missing sound file, and the guards under test, open a message box.
-
-    The config is stubbed to the defaults rather than read from disk, so the
-    window under test does not vary with whatever the developer happens to
-    have configured.
+    The isolated config file is written first, so _check_first_launch() finds
+    it and shows no welcome dialog, and the update check is switched off so no
+    background thread starts. Every window built here is destroyed at teardown.
     """
-    monkeypatch.setattr(mw.MainWindow, "_check_first_launch", lambda self: None)
-    monkeypatch.setattr(
-        mw, "load_config", lambda: {**DEFAULT_CONFIG, "auto_check_updates": False}
-    )
-    monkeypatch.setattr(mw.wx, "MessageBox", lambda *args, **kwargs: None)
+    built = []
 
-    window = mw.MainWindow(None, "Sim-CPDLC test", logger)
-    window.Hide()
-    yield window
-    window.weather_monitor.clear()
-    window.weather_monitor.shutdown()
-    window.Destroy()
+    def build():
+        assert save_config({**DEFAULT_CONFIG, "auto_check_updates": False})
+        window = mw.MainWindow(None, "Sim-CPDLC test", logger)
+        window.Hide()
+        built.append(window)
+        return window
+
+    yield build
+    for window in built:
+        window.weather_monitor.clear()
+        window.weather_monitor.shutdown()
+        window.Destroy()
+
+
+@pytest.fixture
+def window(build_window):
+    return build_window()
 
 
 def last_row(window):

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -10,6 +10,7 @@ stripped-down frame; this builds the whole window.
 """
 
 import pytest
+import wx
 
 import src.gui.main_window as mw
 from src.config import DEFAULT_CONFIG, save_config
@@ -19,25 +20,30 @@ from src.model.weather_monitor import WeatherSubscription
 
 MENU_TITLES = ["File", "Requests"]
 
-# wx does not expose which handler a menu item is bound to, so the menus are
-# checked for shape and the handlers are checked for existence by name.
-MENU_HANDLERS = [
-    "on_connect_or_disconnect",
-    "on_settings",
-    "on_check_updates",
-    "on_about",
-    "on_exit",
-    "on_pdc_request",
-    "on_logon",
-    "on_logoff",
-    "on_altitude_change",
-    "on_direct_request",
-    "on_speed_request",
-    "on_when_can_we_expect",
-    "on_telex",
-    "on_weather_request",
-    "on_weather_subscriptions",
-]
+# Which handler each menu item must fire. Every handler is replaced on the
+# class before the window is built, so the Bind() calls in _init_menu pick up
+# the recorders; posting the item's command event then shows which one ran.
+MENU_BINDINGS = {
+    "File": {
+        "Connect": "on_connect_or_disconnect",
+        "Settings": "on_settings",
+        "Check for Updates": "on_check_updates",
+        "About": "on_about",
+        "Exit": "on_exit",
+    },
+    "Requests": {
+        "PDC": "on_pdc_request",
+        "Logon": "on_logon",
+        "Logoff": "on_logoff",
+        "Altitude change": "on_altitude_change",
+        "Direct to": "on_direct_request",
+        "Speed change": "on_speed_request",
+        "When can we expect": "on_when_can_we_expect",
+        "Telex message": "on_telex",
+        "ATIS and Weather request": "on_weather_request",
+        "Automatic weather updates": "on_weather_subscriptions",
+    },
+}
 
 
 @pytest.fixture
@@ -172,19 +178,44 @@ def test_no_mnemonic_collides_within_a_menu_or_the_menu_bar(window):
     assert collisions == {}, f"Menu bar: colliding mnemonic(s) {collisions}"
 
 
-def test_every_menu_item_has_a_handler(window):
-    missing = [
-        name for name in MENU_HANDLERS if not callable(getattr(window, name, None))
-    ]
+def _recorder(name, fired):
+    def handler(self, event):
+        fired.append(name)
 
-    assert missing == []
+    return handler
+
+
+def test_every_menu_item_fires_its_own_handler(build_window, monkeypatch):
+    """A deleted or mis-targeted Bind() shows up as a dead or wrong menu item;
+    checking that the methods merely exist could not see either."""
+    fired = []
+    for names in MENU_BINDINGS.values():
+        for name in names.values():
+            monkeypatch.setattr(mw.MainWindow, name, _recorder(name, fired))
+    window = build_window()
+    menu_bar = window.GetMenuBar()
+
+    observed = {}
+    for menu_index in range(menu_bar.GetMenuCount()):
+        title = menu_bar.GetMenuLabel(menu_index).replace("&", "")
+        for item in menu_bar.GetMenu(menu_index).GetMenuItems():
+            if item.IsSeparator():
+                continue
+            fired.clear()
+            window.ProcessEvent(wx.CommandEvent(wx.wxEVT_MENU, item.GetId()))
+            observed.setdefault(title, {})[item.GetItemLabelText()] = (
+                fired[0] if len(fired) == 1 else list(fired)
+            )
+
+    assert observed == MENU_BINDINGS
 
 
 # --- guards -------------------------------------------------------------------
 
 
-def test_a_request_needing_a_connection_is_refused_while_disconnected(window):
+def test_a_request_needing_a_connection_is_refused_and_the_user_is_told(window, message_boxes):
     assert window._require_connection("test") is False
+    assert message_boxes.captions == ["Not Connected"]
 
 
 # --- the message list ---------------------------------------------------------

--- a/tests/test_main_window_wiring.py
+++ b/tests/test_main_window_wiring.py
@@ -9,7 +9,7 @@ here rather than at application startup.
 import pytest
 import wx
 
-from conftest import FakeConnectionManager, uplink
+from tests.support import FakeConnectionManager, uplink
 from src.gui.main_window import MainWindow
 from src.model.cpdlc_session import CpdlcSession
 from src.model.message_manager import MessageManager

--- a/tests/test_message_formatting.py
+++ b/tests/test_message_formatting.py
@@ -1,0 +1,40 @@
+"""The CPDLC packet-to-text helpers the list and the detail pane rely on."""
+
+import pytest
+from hoppie_connector import CpdlcResponseRequirement as RR
+
+from src.utils.message_formatting import (
+    extract_message_content,
+    format_list_text,
+    format_message_text,
+)
+
+
+@pytest.mark.parametrize("rr", list(RR), ids=[rr.name for rr in RR])
+def test_the_packet_prefix_is_stripped_with_and_without_an_mrn(rr):
+    assert extract_message_content(f"/data2/12//{rr.value}/CLIMB TO FL350") == "CLIMB TO FL350"
+    assert extract_message_content(f"/data2/12/3/{rr.value}/WILCO") == "WILCO"
+
+
+@pytest.mark.parametrize("text", ["CLIMB TO FL350", "", None], ids=["plain", "empty", "none"])
+def test_text_without_a_prefix_is_returned_unchanged(text):
+    assert extract_message_content(text) == text
+
+
+def test_the_detail_pane_puts_each_field_on_its_own_line():
+    assert format_message_text("CONTACT CLEVELAND CENTER ON @123.450@.") == (
+        "CONTACT CLEVELAND CENTER ON\n123.450."
+    )
+    assert format_message_text("CURRENT ATC UNIT@_@EDUU@_@RHEIN RADAR") == (
+        "CURRENT ATC UNIT\nEDUU\nRHEIN RADAR"
+    )
+
+
+def test_the_list_row_carries_no_separators():
+    row = format_list_text("CONTACT CLEVELAND CENTER ON @123.450@.")
+
+    assert "@" not in row
+    assert "123.450" in row
+    assert format_list_text("CURRENT ATC UNIT@_@EDUU@_@RHEIN RADAR").split() == [
+        "CURRENT", "ATC", "UNIT", "EDUU", "RHEIN", "RADAR",
+    ]

--- a/tests/test_message_manager.py
+++ b/tests/test_message_manager.py
@@ -1,5 +1,7 @@
 """Tests for message identity, acknowledgement state and response options."""
 
+import pytest
+
 from tests.support import uplink
 from hoppie_connector import CpdlcResponseRequirement as RR
 
@@ -129,3 +131,26 @@ def test_a_weather_report_reaches_the_reader_without_separators(logger):
     assert "@" not in row
     assert "@" not in detail
     assert detail == "ATIS EGLL\n\nEGLL ATIS INFO K\nRWY IN USE 27R"
+
+
+RESPONSE_TABLE = [
+    (RR.WILCO_UNABLE, ["WILCO", "UNABLE", "STANDBY"]),
+    (RR.AFFIRM_NEGATIVE, ["AFFIRM", "NEGATIVE", "STANDBY"]),
+    (RR.ROGER, ["ROGER", "STANDBY"]),
+    (RR.YES, ["YES", "NO"]),
+    (RR.NO, []),
+    (RR.NOT_REQUIRED, []),
+]
+
+
+def test_the_response_table_covers_every_requirement_code():
+    assert {rr for rr, _ in RESPONSE_TABLE} == set(RR)
+
+
+@pytest.mark.parametrize("rr, expected", RESPONSE_TABLE, ids=[rr.name for rr, _ in RESPONSE_TABLE])
+def test_the_responses_offered_for_each_requirement_code(logger, rr, expected):
+    """TODOS item 22: "Y" once offered only YES, and "N" wrongly offered NO."""
+    manager = MessageManager(logger)
+    message_id = manager.add_message(uplink(STATION, 9, "CONFIRM SQUAWK", rr=rr))
+
+    assert manager.needs_acknowledgement(message_id, STATION) == (bool(expected), expected)

--- a/tests/test_message_manager.py
+++ b/tests/test_message_manager.py
@@ -1,6 +1,6 @@
 """Tests for message identity, acknowledgement state and response options."""
 
-from conftest import uplink
+from tests.support import uplink
 from hoppie_connector import CpdlcResponseRequirement as RR
 
 from src.model.message_manager import MessageManager

--- a/tests/test_message_view.py
+++ b/tests/test_message_view.py
@@ -3,7 +3,7 @@
 import pytest
 import wx
 
-from conftest import uplink
+from tests.support import uplink
 from src.gui.message_view import MessageView
 from src.model.message_manager import MessageManager
 

--- a/tests/test_message_view.py
+++ b/tests/test_message_view.py
@@ -88,3 +88,34 @@ def test_the_weather_menu_hands_back_the_report_it_was_opened_on(panel, logger):
     view.on_context_menu(None)
 
     assert toggled == [("EGLL", "metar", text)]
+
+
+def test_the_response_menu_offers_every_response_and_fires_the_chosen_one(panel, logger):
+    """The menu is destroyed as soon as it closes, so its items are captured
+    inside the fake PopupMenu; the second item is chosen from there. TODOS
+    item 2: the per-item bindings must be gone once the menu has closed, or a
+    reused id would fire a stale response."""
+    manager = MessageManager(logger)
+    acknowledged = []
+    view = MessageView(
+        panel, logger, manager, lambda mid, resp: acknowledged.append((mid, resp)), lambda: STATION
+    )
+    message_id = manager.add_message(uplink(STATION, 4))
+    shown = {}
+
+    def choose_second(menu):
+        shown["labels"] = [item.GetItemLabelText() for item in menu.GetMenuItems()]
+        shown["ids"] = [item.GetId() for item in menu.GetMenuItems()]
+        panel.ProcessEvent(wx.CommandEvent(wx.wxEVT_MENU, shown["ids"][1]))
+
+    panel.PopupMenu = choose_second
+    view.add_message(message_id)
+    view.message_list.Select(0)
+
+    view.on_context_menu(None)
+
+    assert shown["labels"] == ["Respond: WILCO", "Respond: UNABLE", "Respond: STANDBY"]
+    assert acknowledged == [(message_id, "UNABLE")]
+
+    panel.ProcessEvent(wx.CommandEvent(wx.wxEVT_MENU, shown["ids"][1]))
+    assert acknowledged == [(message_id, "UNABLE")], "binding survived the menu"

--- a/tests/test_polling_controller.py
+++ b/tests/test_polling_controller.py
@@ -4,7 +4,7 @@ import logging
 
 import pytest
 
-from conftest import FakeConnectionManager, uplink
+from tests.support import FakeConnectionManager, uplink
 from hoppie_connector import CpdlcResponseRequirement as RR
 
 from src.controller.polling_controller import PollingController

--- a/tests/test_uplink_handling.py
+++ b/tests/test_uplink_handling.py
@@ -1,0 +1,141 @@
+"""How the window reacts to uplinks that change session state or tune the radio.
+
+These drive MainWindow._on_message_received with the exact texts the two
+networks send, taken from the maintainer's logs.
+"""
+
+import pytest
+from hoppie_connector import CpdlcResponseRequirement as RR
+
+from tests.support import (
+    FakeConnectionManager,
+    FakeSimConnectManager,
+    make_main_window,
+    uplink,
+)
+from src.model.cpdlc_session import CpdlcSession
+from src.model.message_manager import MessageManager
+
+CURRENT = "EDYY"
+OTHER = "EDUU"
+CONTACT = "CONTACT MARSEILLE CONTROL ON @133.325@."
+
+
+def build(logger, config=None, simconnect=None):
+    connection = FakeConnectionManager()
+    session = CpdlcSession(logger, connection)
+    session.set_callsign("DLH123")
+    session.handle_logon_accepted(CURRENT)
+    simconnect = simconnect if simconnect is not None else FakeSimConnectManager()
+    window = make_main_window(
+        logger, session, MessageManager(logger), config=config, simconnect=simconnect
+    )
+    return window, session, connection, simconnect
+
+
+# --- handover -----------------------------------------------------------------
+
+
+def test_a_handover_logs_off_and_requests_logon_with_the_next_station(logger):
+    window, session, connection, _ = build(logger)
+
+    window._on_message_received(uplink(CURRENT, 48, "HANDOVER @EDGG@", rr=RR.NOT_REQUIRED))
+
+    assert session.get_current_station() == ""
+    assert session.pending_logon_station == "EDGG"
+    assert connection.sent == [("EDGG", 1, RR.YES.value, "REQUEST LOGON", None)]
+    assert window.status_texts == ["Logged off from EDYY.", "Pending logon to EDGG."]
+    assert window.polling_controller.active_calls == 1
+
+
+def test_a_handover_from_another_station_is_shown_but_not_acted_on(logger):
+    window, session, connection, _ = build(logger)
+
+    window._on_message_received(uplink(OTHER, 48, "HANDOVER @EDGG@", rr=RR.NOT_REQUIRED))
+
+    assert session.get_current_station() == CURRENT
+    assert connection.sent == []
+    assert window.status_texts == []
+    assert len(window.message_view.added) == 1
+
+
+# --- logoff -------------------------------------------------------------------
+
+
+def test_a_logoff_from_the_current_station_ends_the_logon(logger):
+    window, session, _, _ = build(logger)
+
+    window._on_message_received(uplink(CURRENT, 5, "LOGOFF", rr=RR.NOT_REQUIRED))
+
+    assert session.get_current_station() == ""
+    assert window.status_texts == ["Logged off from EDYY."]
+
+
+@pytest.mark.parametrize(
+    "sender, text",
+    [(OTHER, "LOGOFF"), (CURRENT, "LOGOFF NOT REQUIRED AT THIS TIME")],
+    ids=["other-station", "not-an-exact-logoff"],
+)
+def test_other_logoff_texts_leave_the_logon_alone(logger, sender, text):
+    """TODOS item 23: substring matching once logged off on the second text."""
+    window, session, _, _ = build(logger)
+
+    window._on_message_received(uplink(sender, 5, text, rr=RR.NOT_REQUIRED))
+
+    assert session.get_current_station() == CURRENT
+    assert window.status_texts == []
+
+
+# --- protocol noise -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["CURRENT ATC UNIT@_@EDYY@_@MAASTRICHT RADAR", "CURRENT ATS UNIT@_@EDYY@_@MAASTRICHT RADAR"],
+    ids=["atc", "ats"],
+)
+def test_current_unit_announcements_are_hidden(logger, text):
+    window, _, _, _ = build(logger)
+
+    window._on_message_received(uplink(CURRENT, 2, text, rr=RR.NOT_REQUIRED))
+
+    assert window.message_view.added == []
+    assert window.message_manager.message_log == {}
+    assert window.status_texts == []
+
+
+# --- CONTACT / MONITOR auto-tune ----------------------------------------------
+
+
+def test_a_contact_instruction_tunes_the_standby_radio(logger):
+    window, _, _, simconnect = build(logger)
+
+    window._on_message_received(uplink(CURRENT, 7, CONTACT))
+
+    assert simconnect.tuned == [133.325]
+    assert window.status_texts == []
+
+
+def test_auto_tune_can_be_switched_off(logger):
+    window, _, _, simconnect = build(logger, config={"auto_tune_com1": False})
+
+    window._on_message_received(uplink(CURRENT, 7, CONTACT))
+
+    assert simconnect.tuned == []
+
+
+def test_a_failed_auto_tune_tells_the_pilot_the_frequency(logger):
+    window, _, _, simconnect = build(logger, simconnect=FakeSimConnectManager(result=False))
+
+    window._on_message_received(uplink(CURRENT, 7, CONTACT))
+
+    assert simconnect.tuned == [133.325]
+    assert window.status_texts == ["Auto-tune failed \u2014 set 133.325 manually"]
+
+
+def test_a_contact_from_another_station_is_not_tuned(logger):
+    window, _, _, simconnect = build(logger)
+
+    window._on_message_received(uplink(OTHER, 7, CONTACT))
+
+    assert simconnect.tuned == []


### PR DESCRIPTION
## Summary

Package 1 of the audit fix programme: the test suite becomes hermetic and the CPDLC protocol behaviour that later packages must not break is pinned. Nothing under `src/` changes.

This branch also carries the documents the work is based on: the codebase audit (`docs/audit/`), the umbrella design for all six packages (`docs/superpowers/specs/2026-09-03-audit-fixes-design.md`) and this package's plan (`docs/superpowers/plans/2026-09-03-pkg1-test-harness.md`).

## What changed

- **Test doubles** move from `tests/conftest.py` into `tests/support.py` (`uplink` now takes an MRN, `FakeConnectionManager` can raise and records telexes, new `FakeSimConnectManager`, `make_main_window` takes a config and a SimConnect fake).
- **Hermetic autouse fixtures** in `tests/conftest.py`: the config file is a per-test temporary path; `requests.get`/`post`/`request`, `Session.request` and `webbrowser.open` refuse to run; SimBrief lookups answer with no flight plan; `wx.MessageBox` and `wx.MessageDialog` are recorders; the `wx_app` fixture fails any test that leaks a top-level window. `tests/test_harness.py` proves each guarantee with real objects (a real `ConnectDialog` with a SimBrief id configured, a real first-launch `MainWindow` with no config file).
- **Timeouts**: `pytest-timeout` with 60 s per test, `timeout-minutes: 15` on the CI job.
- **Regression tests** for behaviour the audit found unguarded: the full acknowledgement frame down to the literal `/data2/1/53/N/WILCO` packet built by the real `hoppie_connector`; the MRN check on `LOGON ACCEPTED`; the response table over all six requirement codes; every downlink text and every send failure path; the HANDOVER, LOGOFF, `CURRENT ATC UNIT` and CONTACT auto-tune branches of `_on_message_received`; menu items driven with `ProcessEvent` and matched to their handlers; the response context menu's items, firing and cleanup; `load_config`/`save_config` including the atomic write; table tests for the frequency parser and the packet formatters.

Suite: 135 → 216 tests, all green; each protocol guard was mutation-checked (temporarily breaking the guarded line made exactly the intended test fail).

## Notes for review

- Behaviour that later packages change is deliberately not pinned here (strict station scoping after a handover, the `@@` → `N/A` substitution, the single reconnection attempt, unit-less CONTACT texts).
- Package 3 is expected to rewrite `test_a_contact_from_another_station_is_not_tuned` and `test_a_handover_from_another_station_is_shown_but_not_acted_on` when the previous-station response window lands.
- The import-time `os.makedirs` in `src/config.py` still creates the real user-data directory on every run; it needs a `src/` change and is left for package 6.

## Test plan

- [x] `pytest` from the repository root: 216 passed, no warnings, no leaked windows
- [x] Mutation checks for the acknowledgement RR, the MRN check, a deleted menu `Bind`, and the context-menu `Unbind` loop each fail the intended test
- [x] No file under `src/` modified (`git diff --stat main...HEAD -- src` is empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
